### PR TITLE
Add exceptions and reuse package_item snippet

### DIFF
--- a/ckanext/opendata_theme/opengov_custom_homepage/helpers.py
+++ b/ckanext/opendata_theme/opengov_custom_homepage/helpers.py
@@ -13,61 +13,88 @@ logger = logging.getLogger(__name__)
 def dataset_count():
     """Return a count of all datasets"""
     count = 0
-    result = toolkit.get_action('package_search')({}, {'rows': 1})
-    if result.get('count'):
-        count = result.get('count')
+    try:
+        result = toolkit.get_action('package_search')({}, {'rows': 1})
+        if result.get('count'):
+            count = result.get('count')
+    except Exception:
+        logger.debug("[opendata_theme] Error getting dataset count")
+        return 0
     return count
 
 
 def showcases(num=24):
     """Return a list of showcases"""
-    sorted_showcases = []
-    showcases = toolkit.get_action('ckanext_showcase_list')({}, {})
-    sorted_showcases = sorted(showcases, key=lambda k: k.get('position'))
-    return sorted_showcases[:num]
+    showcases = []
+    try:
+        showcases = toolkit.get_action('ckanext_showcase_list')({}, {})
+    except Exception:
+        logger.debug("[opendata_theme] Error getting showcase list")
+        return []
+    return showcases[:num]
 
 
 def groups(num=12):
     """Return a list of groups"""
-    groups = toolkit.get_action('group_list')({}, {'all_fields': True, 'sort': 'packages'})
+    groups = []
+    try:
+        groups = toolkit.get_action('group_list')({}, {'all_fields': True, 'sort': 'packages'})
+    except Exception:
+        logger.debug("[opendata_theme] Error getting group list")
+        return []
     return groups[:num]
-
-
-def recent_datasets(num=5):
-    """Return a list of recent datasets."""
-    sorted_datasets = []
-    datasets = toolkit.get_action('current_package_list_with_resources')({}, {'limit': num})
-    if datasets:
-        sorted_datasets = sorted(datasets, key=lambda k: k['metadata_modified'], reverse=True)
-    return sorted_datasets[:num]
-
-
-def new_datasets(num=3):
-    """Return a list of the newest datasets."""
-    datasets = []
-    search = toolkit.get_action('package_search')({}, {'rows': num, 'sort': 'metadata_created desc'})
-    if search.get('results'):
-        datasets = search.get('results')
-    return datasets[:num]
 
 
 def popular_datasets(num=5):
     """Return a list of popular datasets."""
     datasets = []
-    search = toolkit.get_action('package_search')({}, {'rows': num, 'sort': 'views_recent desc'})
-    if search.get('results'):
-        datasets = search.get('results')
+    try:
+        search = toolkit.get_action('package_search')({}, {'rows': num, 'sort': 'views_recent desc'})
+        if search.get('results'):
+            datasets = search.get('results')
+    except Exception:
+        logger.debug("[opendata_theme] Error getting popular datasets")
+        return []
     return datasets[:num]
 
 
-def get_package_metadata(package):
-    """Return the metadata of a dataset"""
-    result = {}
+def recent_datasets(num=5):
+    """Return a list of recently updated/created datasets."""
+    sorted_datasets = []
     try:
-        result = toolkit.get_action('package_show')(None, {'id': package.get('name'), 'include_tracking': True})
+        datasets = toolkit.get_action('current_package_list_with_resources')({}, {'limit': num})
+        if datasets:
+            sorted_datasets = sorted(datasets, key=lambda k: k['metadata_modified'], reverse=True)
     except Exception:
-        logger.warning("[og_theme] Error in retrieving dataset metadata for " + str(package))
-    return result
+        logger.debug("[opendata_theme] Error getting recently updated/created datasets")
+        return []
+    return sorted_datasets[:num]
+
+
+def new_datasets(num=3):
+    """Return a list of the newly created datasets."""
+    datasets = []
+    try:
+        search = toolkit.get_action('package_search')({}, {'rows': num, 'sort': 'metadata_created desc'})
+        if search.get('results'):
+            datasets = search.get('results')
+    except Exception:
+        logger.debug("[opendata_theme] Error getting newly created datasets")
+        return []
+    return datasets[:num]
+
+
+def package_tracking_summary(package):
+    """Return the tracking summary of a dataset"""
+    tracking_summary = {}
+    try:
+        result = toolkit.get_action('package_show')({}, {'id': package.get('name'), 'include_tracking': True})
+        if result.get('tracking_summary'):
+            tracking_summary = result.get('tracking_summary')
+    except Exception:
+        logger.debug("[opendata_theme] Error getting dataset tracking_summary")
+        return {}
+    return tracking_summary
 
 
 def get_custom_name(key, default_name):
@@ -78,10 +105,10 @@ def get_custom_name(key, default_name):
     name = custom_naming.get(key)
     if not name:
         return default_name
-    elif not name['value']:
+    elif not name.get('value'):
         return default_name
     else:
-        return name['value']
+        return name.get('value')
 
 
 def get_data(key):

--- a/ckanext/opendata_theme/opengov_custom_homepage/plugin/__init__.py
+++ b/ckanext/opendata_theme/opengov_custom_homepage/plugin/__init__.py
@@ -50,7 +50,7 @@ class Opendata_ThemePlugin(MixinPlugin):
             'opendata_theme_get_datasets_new': helper.new_datasets,
             'opendata_theme_get_datasets_popular': helper.popular_datasets,
             'opendata_theme_get_datasets_recent': helper.recent_datasets,
-            'opendata_theme_get_package_metadata': helper.get_package_metadata,
+            'opendata_theme_get_package_tracking_summary': helper.package_tracking_summary,
             'opendata_theme_get_custom_name': helper.get_custom_name,
             'opendata_theme_get_data': helper.get_data,
             'version': version_builder,

--- a/ckanext/opendata_theme/opengov_custom_homepage/templates/home/snippets/package_item.html
+++ b/ckanext/opendata_theme/opengov_custom_homepage/templates/home/snippets/package_item.html
@@ -4,70 +4,81 @@ Displays a single of dataset.
 package        - A package to display.
 item_class     - The class name to use on the list item.
 hide_resources - If true hides the resources (default: false).
-banner         - If true displays a popular banner (default: false).
-truncate       - The length to trucate the description to (default: 180)
-truncate_title - The length to truncate the title to (default: 80).
+truncate_title - The length to truncate the title to (default: 120).
+note_type      - The type of note to display: updated or recent_views (default: updated).
 
 Example:
 
   {% snippet 'snippets/package_item.html', package=c.datasets[0] %}
 
 #}
-{% set truncate = truncate or 180 %}
-{% set truncate_title = truncate_title or 80 %}
+{% set truncate_title = truncate_title or 120 %}
 {% set title = package.title or package.name %}
-{% set notes = h.markdown_extract(package.notes, extract_length=truncate) %}
+{% set note_type = note_type or 'updated' %}
+
+{% if h.version(h.ckan_version()) < h.version('2.9') %}
+  {% set package_url = h.url_for(controller='package', action='read', id=package.name) %}
+{% else %}
+  {% set package_url = h.url_for(package.type ~ '.read', id=package.name) %}
+{% endif %}
 
 {% block package_item %}
-    <li class="{{ item_class or "dataset-item" }}">
-        {% block content %}
-            <div class="dataset-content">
-                {% block heading %}
-                    <h3 class="dataset-heading">
-                        {% block heading_private %}
-                            {% if package.private %}
-                                <span class="dataset-private label label-inverse">
-                  <i class="fa fa-lock"></i>
-                  {{ _('Private') }}
-                </span>
-                            {% endif %}
-                        {% endblock %}
-                        {% block heading_title %}
-                            {{ h.link_to(h.truncate(title, truncate_title), h.url_for(controller='dataset', action='read', id=package.name)) }}
-                        {% endblock %}
-                        {% block heading_meta %}
-                            {% if package.get('state', '').startswith('draft') %}
-                                <span class="label label-info">{{ _('Draft') }}</span>
-                            {% elif package.get('state', '').startswith('deleted') %}
-                                <span class="label label-important">{{ _('Deleted') }}</span>
-                            {% endif %}
-                            {{ h.popular('recent views', package.tracking_summary.recent, min=10) if package.tracking_summary }}
-                        {% endblock %}
-                    </h3>
-                {% endblock %}
-                {% block notes %}
-                    {% if package.metadata_modified %}
-                        <div>Updated on {{ h.render_datetime(package.metadata_modified) }}</div>
-                    {% endif %}
-                {% endblock %}
-                {% block resources %}
-                    {% if package.resources and not hide_resources %}
-                        {% block resources_outer %}
-                            <ul class="dataset-resources unstyled">
-                                {% block resources_inner %}
-                                    {% for resource in h.dict_list_reduce(package.resources, 'format') %}
-                                        <li>
-                                            <a href="{{ h.url_for(controller='package', action='read', id=package.name) }}"
-                                               class="label" data-format="{{ resource.lower() }}"
-                                               style="color:white;">{{ resource }}</a>
-                                        </li>
-                                    {% endfor %}
-                                {% endblock %}
-                            </ul>
-                        {% endblock %}
-                    {% endif %}
-                {% endblock %}
-            </div>
+  <li class="{{ item_class or "dataset-item" }}">
+    {% block content %}
+      <div class="dataset-content">
+        {% block heading %}
+          <h3 class="dataset-heading">
+            {% block heading_private %}
+              {% if package.private %}
+              <span class="dataset-private label label-inverse">
+                <i class="fa fa-lock"></i>
+                {{ _('Private') }}
+              </span>
+              {% endif %}
+            {% endblock %}
+            {% block heading_title %}
+              {{ h.link_to(h.truncate(title, truncate_title), package_url) }}
+            {% endblock %}
+            {% block heading_meta %}
+              {% if package.get('state', '').startswith('draft') %}
+                <span class="label label-info">{{ _('Draft') }}</span>
+              {% elif package.get('state', '').startswith('deleted') %}
+                <span class="label label-important">{{ _('Deleted') }}</span>
+              {% endif %}
+              {{ h.popular('recent views', package.tracking_summary.recent, min=10) if package.tracking_summary }}
+            {% endblock %}
+          </h3>
         {% endblock %}
-    </li>
+        {% block notes %}
+          {% if note_type == 'updated' %}
+            {% if package.metadata_modified %}
+              <div>Updated on {{ h.render_datetime(package.metadata_modified) }}</div>
+            {% endif %}
+          {% elif note_type == 'recent_views' %}
+            {% set tracking_summary = h.opendata_theme_get_package_tracking_summary(package) %}
+            {% if tracking_summary %}
+                <div>{{ tracking_summary.recent }} recent views</div>
+            {% endif %}
+          {% endif %}
+        {% endblock %}
+        {% block resources %}
+          {% if package.resources and not hide_resources %}
+            {% block resources_outer %}
+              <ul class="dataset-resources unstyled list-unstyled">
+                {% block resources_inner %}
+                  {% for resource in h.dict_list_reduce(package.resources, 'format') %}
+                    <li>
+                      <a href="{{ package_url }}" class="label label-default" data-format="{{ resource.lower() }} aria-label="Access {{resource}} resources from dataset {{title}}">
+                        {{ resource }}
+                      </a>
+                    </li>
+                  {% endfor %}
+                {% endblock %}
+              </ul>
+            {% endblock %}
+          {% endif %}
+        {% endblock %}
+      </div>
+    {% endblock %}
+  </li>
 {% endblock %}

--- a/ckanext/opendata_theme/opengov_custom_homepage/templates/home/snippets/package_list.html
+++ b/ckanext/opendata_theme/opengov_custom_homepage/templates/home/snippets/package_list.html
@@ -5,9 +5,8 @@ packages       - A list of packages to display.
 list_class     - The class name for the list item.
 item_class     - The class name to use on each item.
 hide_resources - If true hides the resources (default: false).
-banner         - If true displays a popular banner (default: false).
-truncate       - The length to trucate the description to (default: 180)
-truncate_title - The length to truncate the title to (default: 80).
+truncate_title - The length to truncate the title to (default: 120).
+note_type      - The type of note to display: updated or recent_views (default: updated).
 
 Example:
 
@@ -15,13 +14,13 @@ Example:
 
 #}
 {% block package_list %}
-    {% if packages %}
-        <ul class="{{ list_class or 'dataset-list unstyled' }}">
-            {% block package_list_inner %}
-                {% for package in packages %}
-                    {% snippet 'home/snippets/package_item.html', package=package, item_class=item_class, hide_resources=hide_resources, banner=banner, truncate=truncate, truncate_title=truncate_title %}
-                {% endfor %}
-            {% endblock %}
-        </ul>
-    {% endif %}
+  {% if packages %}
+    <ul class="{{ list_class or 'dataset-list unstyled list-unstyled' }}">
+      {% block package_list_inner %}
+        {% for package in packages %}
+          {% snippet 'home/snippets/package_item.html', package=package, item_class=item_class, hide_resources=hide_resources, truncate_title=truncate_title, note_type=note_type %}
+        {% endfor %}
+      {% endblock %}
+    </ul>
+  {% endif %}
 {% endblock %}

--- a/ckanext/opendata_theme/opengov_custom_homepage/templates/home/snippets/popular_datasets.html
+++ b/ckanext/opendata_theme/opengov_custom_homepage/templates/home/snippets/popular_datasets.html
@@ -1,34 +1,11 @@
 {% set popular_datasets = h.opendata_theme_get_datasets_popular() %}
 
 <div class="module-content">
-    <header>
-        <h2 class="heading">{{ h.opendata_theme_get_custom_name('datasets-popular-custom-name', 'Popular Datasets') }}</h2>
-        <hr/>
-    </header>
-    <section>
-        <ul id="popular-list" class="unstyled dataset-list">
-            {% for package in popular_datasets %}
-                <li class="dataset-item">
-                    <div class="dataset-content">
-                        <h3 class="dataset-heading">{{ h.link_to(package.title or package.name, h.url_for(controller='dataset', action='read', id=package.name)) }}</h3>
-                        {% set curr_package = h.opendata_theme_get_package_metadata(package) %}
-                        {% if curr_package %}
-                            <div>{{ curr_package.tracking_summary.recent }} recent views</div>
-                            {% if curr_package.resources %}
-                                <ul class="dataset-resources unstyled">
-                                    {% for resource in h.dict_list_reduce(curr_package.resources, 'format') %}
-                                        <li>
-                                            <a href="{{ h.url_for(controller='package', action='read', id=package.name) }}"
-                                               class="label" data-format="{{ resource.lower() }}"
-                                               >{{ resource }}</a>
-                                        </li>
-                                    {% endfor %}
-                                </ul>
-                            {% endif %}
-                        {% endif %}
-                    </div>
-                </li>
-            {% endfor %}
-        </ul>
-    </section>
+  <header>
+    <h2 class="heading">{{ h.opendata_theme_get_custom_name('datasets-popular-custom-name', 'Popular Datasets') }}</h2>
+    <hr/>
+  </header>
+  <section>
+    {% snippet 'home/snippets/package_list.html', packages=popular_datasets, note_type='recent_views' %}
+  </section>
 </div>

--- a/ckanext/opendata_theme/opengov_custom_homepage/templates/home/snippets/recent_datasets.html
+++ b/ckanext/opendata_theme/opengov_custom_homepage/templates/home/snippets/recent_datasets.html
@@ -1,11 +1,11 @@
 {% set latest_datasets = h.opendata_theme_get_datasets_recent() %}
 
 <div class="module-content">
-    <header>
-        <h2 class="heading">{{ h.opendata_theme_get_custom_name('datasets-recent-custom-name', 'New and Recent Datasets') }}</h2>
-        <hr/>
-    </header>
-    <section>
-        {% snippet 'home/snippets/package_list.html', packages=latest_datasets %}
-    </section>
+  <header>
+    <h2 class="heading">{{ h.opendata_theme_get_custom_name('datasets-recent-custom-name', 'New and Recent Datasets') }}</h2>
+    <hr/>
+  </header>
+  <section>
+    {% snippet 'home/snippets/package_list.html', packages=latest_datasets, note_type='updated' %}
+  </section>
 </div>


### PR DESCRIPTION
## Description
This PR fixes the popular datasets and recent datasets section on the homepage, by adding support for ckan 2.9 when getting dataset links.

The snippet below determines how to get the dataset url:
```
{% if h.version(h.ckan_version()) < h.version('2.9') %}
  {% set package_url = h.url_for(controller='package', action='read', id=package.name) %}
{% else %}
  {% set package_url = h.url_for(package.type ~ '.read', id=package.name) %}
{% endif %}
```