### PR TITLE
[OD-2078] Update header logic

### DIFF
--- a/ckanext/opendata_theme/opengov_custom_footer/common_controller.py
+++ b/ckanext/opendata_theme/opengov_custom_footer/common_controller.py
@@ -23,7 +23,7 @@ def clean_html(text):
 
 
 class CustomFooterCommonController(BaseCompatibilityController):
-    default_data = {'layout_type': 'default'}
+    default_footer = {'layout_type': 'default'}
 
     def custom_footer(self):
         try:
@@ -59,7 +59,7 @@ class CustomFooterCommonController(BaseCompatibilityController):
         else:
             custom_footer_route = 'custom_footer'
 
-        self.save_footer_metadata({})
+        self.save_footer_metadata(CustomFooterCommonController.default_footer)
         return tk.redirect_to(custom_footer_route)
 
     @staticmethod
@@ -73,5 +73,5 @@ class CustomFooterCommonController(BaseCompatibilityController):
     def get_custom_footer_metadata():
         data = CustomFooterCommonController.get_data(CONFIG_KEY)
         if not data:
-            data = CustomFooterCommonController.default_data.copy()
+            data = CustomFooterCommonController.default_footer.copy()
         return data

--- a/ckanext/opendata_theme/opengov_custom_header/constants.py
+++ b/ckanext/opendata_theme/opengov_custom_header/constants.py
@@ -1,3 +1,2 @@
 CONFIG_SECTION = 'ckanext.opendata_theme.custom_header.data'
-DEFAULT_CONFIG_SECTION = 'ckanext.opendata_theme.custom_header.default_data'
 CONTROLLER = 'ckanext.opendata_theme.opengov_custom_header.plugin.pylons_plugin:HeaderController'

--- a/ckanext/opendata_theme/opengov_custom_header/controller.py
+++ b/ckanext/opendata_theme/opengov_custom_header/controller.py
@@ -1,37 +1,23 @@
 # encoding: utf-8
-import six
 import ckan.plugins.toolkit as tk
 from ckan import model
-
-try:
-    from webhelpers.html import literal
-except ModuleNotFoundError:
-    from ckan.lib.helpers import literal  # noqa: F401
 
 import ckanext.opendata_theme.base.helpers as helper
 from ckanext.opendata_theme.opengov_custom_header.constants import CONFIG_SECTION
 from ckanext.opendata_theme.base.compatibility_controller import BaseCompatibilityController
 
 
-class Link(object):
-    def __init__(self, title, url, position, active=False):
-        self.title = six.text_type(title)
-        self.url = six.text_type(url)
-        self.position = position
-        self.active = active
-
-    def __repr__(self):
-        return '{}:{}'.format(self.position, self.title)
-
-    def to_dict(self):
-        return {
-            'position': self.position,
-            'title': self.title,
-            'url': self.url
-        }
-
-
 class CustomHeaderController(BaseCompatibilityController):
+    default_header = {
+        'layout_type': 'default',
+        'links': [
+            {'position': 0, 'title': 'Datasets', 'url': '/dataset'},
+            {'position': 1, 'title': '{}s'.format(helper.get_organization_alias()), 'url': '/organization'},
+            {'position': 2, 'title': '{}s'.format(helper.get_group_alias()), 'url': '/group'},
+            {'position': 3, 'title': 'About', 'url': '/about'}
+        ]
+    }
+
     def custom_header(self):
         try:
             context = {'model': model, 'user': tk.c.user}
@@ -40,13 +26,6 @@ class CustomHeaderController(BaseCompatibilityController):
             tk.abort(403, tk._('Need to be system administrator to administer'))
 
         custom_header = self.get_custom_header_metadata()
-        if not custom_header:
-            # this block is required for base initialization
-            # it happens only once when default custom header metadata is not set
-            # because it is set in build_pages_nav_main helper function which is called
-            # during the page rendering.
-            # reset_custom_header is able to render the page in the background for setting default metadata.
-            self.reset_custom_header()
 
         if tk.request.method == 'POST':
             data = self.get_form_data(tk.request)
@@ -57,19 +36,19 @@ class CustomHeaderController(BaseCompatibilityController):
             if isinstance(data.get('url'), list):
                 for index in range(len(data.get('url'))):
                     custom_header['links'].append(
-                        Link(
-                            title=data['title'][index],
-                            url=data['url'][index],
-                            position=data['position'][index]
-                        )
+                        {
+                            'position': data['position'][index],
+                            'title': data['title'][index],
+                            'url': data['url'][index]
+                        }
                     )
             else:
                 custom_header['links'].append(
-                    Link(
-                        title=data['title'],
-                        url=data['url'],
-                        position=data['position']
-                    )
+                    {
+                        'position': data['position'],
+                        'title': data['title'],
+                        'url': data['url']
+                    }
                 )
             error = self.save_custom_header_metadata(custom_header)
             custom_header['errors'] = error
@@ -92,11 +71,12 @@ class CustomHeaderController(BaseCompatibilityController):
             data = self.get_form_data(tk.request)
             header_data = self.get_custom_header_metadata()
             header_data.get('links', []).append(
-                Link(
-                    title=data.get('new_title'),
-                    url=data.get('new_url'),
-                    position=len(header_data.get('links', [])),
-                ))
+                {
+                    'position': len(header_data.get('links', [])),
+                    'title': data.get('new_title'),
+                    'url': data.get('new_url')
+                }
+            )
             error = self.save_custom_header_metadata(header_data)
             header_data['errors'] = error
             return tk.render('admin/custom_header_form.html',
@@ -118,7 +98,7 @@ class CustomHeaderController(BaseCompatibilityController):
         if tk.request.method == 'POST':
             data = self.get_form_data(tk.request)
             header_data = self.get_custom_header_metadata()
-            item = [link for link in header_data['links'] if link.title == data['to_remove']]
+            item = [link for link in header_data['links'] if link.get('title') == data['to_remove']]
             try:
                 header_data['links'].remove(item[0])
                 error = self.save_custom_header_metadata(header_data)
@@ -141,37 +121,17 @@ class CustomHeaderController(BaseCompatibilityController):
         else:
             custom_header_route = 'custom_header'
 
-        default_header = {
-            'layout_type': 'default',
-            'links': [
-                {'position': 0, 'title': 'Datasets', 'url': '/dataset'},
-                {'position': 1, 'title': helper.get_organization_alias(), 'url': '/organization/'},
-                {'position': 2, 'title': helper.get_group_alias(), 'url': '/group/'},
-                {'position': 3, 'title': 'About', 'url': '/about'}
-            ]
-        }
-        self.save_custom_header_metadata(default_header)
-
+        self.save_custom_header_metadata(CustomHeaderController.default_header)
         return tk.redirect_to(custom_header_route)
 
     def save_custom_header_metadata(self, custom_header):
         try:
-            data_dict = custom_header.copy()
-            links = []
-            for item in custom_header.get('links', []):
-                links.append(item.to_dict())
-            data_dict['links'] = links
-            BaseCompatibilityController.store_data(CONFIG_SECTION, data_dict)
+            CustomHeaderController.store_data(CONFIG_SECTION, custom_header)
         except tk.ValidationError as ex:
             return ex.error_summary
 
     def get_custom_header_metadata(self):
-        data_dict = BaseCompatibilityController.get_data(CONFIG_SECTION)
-        links = []
-        for item in data_dict.get('links', []):
-            if isinstance(item, dict):
-                item = Link(**item)
-            links.append(item)
-        if links:
-            data_dict['links'] = links
+        data_dict = CustomHeaderController.get_data(CONFIG_SECTION)
+        if not data_dict:
+            data_dict = CustomHeaderController.default_header.copy()
         return data_dict

--- a/ckanext/opendata_theme/opengov_custom_header/templates/compressed_header.html
+++ b/ckanext/opendata_theme/opengov_custom_header/templates/compressed_header.html
@@ -9,10 +9,12 @@
   {% set search_route = 'dataset.search' %}
   {% set organizations_index_route = 'organization.index' %}
   {% set group_index_route = 'group.index' %}
+  {% set about_index_route = 'home.about' %}
 {% else %}
   {% set search_route = 'search' %}
   {% set organizations_index_route = 'organization_index' %}
   {% set group_index_route = 'group_index' %}
+  {% set about_index_route = 'about' %}
 {% endif %}
 
 {% block header_wrapper %}
@@ -41,13 +43,10 @@
               {{ h.opendata_theme_build_nav_main(
                 (search_route, _('Datasets')),
                 (organizations_index_route, _(org_alias_pural)),
-                (group_index_route, _(group_alias_pural))
+                (group_index_route, _(group_alias_pural)),
+                (about_index_route, _('About'))
               ) }}
             {% endblock %}
-            {# "About" tab is separated from h.build_nav_main() so that "About" tab is always right aligned #}
-            <li>
-              <a href="{{ h.url_for('/about') }}" title="{{ _('About') }}">{{ _('About') }}</a>
-            </li>
           </ul>
         </nav>
       {% endblock %}

--- a/ckanext/opendata_theme/opengov_custom_header/templates/default_header.html
+++ b/ckanext/opendata_theme/opengov_custom_header/templates/default_header.html
@@ -9,10 +9,12 @@
   {% set search_route = 'dataset.search' %}
   {% set organizations_index_route = 'organization.index' %}
   {% set group_index_route = 'group.index' %}
+  {% set about_index_route = 'home.about' %}
 {% else %}
   {% set search_route = 'search' %}
   {% set organizations_index_route = 'organization_index' %}
   {% set group_index_route = 'group_index' %}
+  {% set about_index_route = 'about' %}
 {% endif %}
 
 {% block header_wrapper %} {% block header_account %}
@@ -48,13 +50,10 @@
               {{ h.opendata_theme_build_nav_main(
                 (search_route, _('Datasets')),
                 (organizations_index_route, _(org_alias_pural)),
-                (group_index_route, _(group_alias_pural))
+                (group_index_route, _(group_alias_pural)),
+                (about_index_route, _('About'))
               ) }}
             {% endblock %}
-            {# "About" tab is separated from h.build_nav_main() so that "About" tab is always right aligned #}
-            <li>
-              <a href="{{ h.url_for('/about') }}" title="{{ _('About') }}">{{ _('About') }}</a>
-            </li>
         </ul>
       </nav>
       {% endblock %}

--- a/ckanext/opendata_theme/tests/opengov_custom_header/test_custom_header.py
+++ b/ckanext/opendata_theme/tests/opengov_custom_header/test_custom_header.py
@@ -7,14 +7,16 @@ RESET_CUSTOM_HEADER_URL = "/ckan-admin/reset_custom_header/"
 ADD_LINK_TO_HEADER_URL = "/ckan-admin/add_link_to_header/"
 REMOVE_LINK_FROM_HEADER_URL = "/ckan-admin/remove_link_from_header/"
 DEFAULT_LINKS = (
-    {'position': 0, 'title': 'Datasets', 'url': '/dataset/'},
-    {'position': 1, 'title': 'Organizations', 'url': '/organization/'},
-    {'position': 2, 'title': 'Groups', 'url': '/group/'}
+    {'position': 0, 'title': 'Datasets', 'url': '/dataset'},
+    {'position': 1, 'title': 'Organizations', 'url': '/organization'},
+    {'position': 2, 'title': 'Groups', 'url': '/group'},
+    {'position': 3, 'title': 'About', 'url': '/about'}
 )
 DEFAULT_HEADERS = (
-    {'title': 'Datasets', 'url': '/dataset/'},
-    {'title': 'Organizations', 'url': '/organization/'},
-    {'title': 'Groups', 'url': '/group/'}
+    {'title': 'Datasets', 'url': '/dataset'},
+    {'title': 'Organizations', 'url': '/organization'},
+    {'title': 'Groups', 'url': '/group'},
+    {'title': 'About', 'url': '/about'},
 )
 
 
@@ -47,19 +49,17 @@ def test_get_custom_header_page(app):
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 def test_add_link_to_custom_header(app):
-    title = 'example'
-    url = 'https://example.com'
     data = {
-        'new_title': title,
-        'new_url': url,
+        'new_title': 'Example',
+        'new_url': 'https://example.com',
     }
     expected_links = [
-        {'position': 3, 'title': title, 'url': url},
+        {'position': 4, 'title': 'Example', 'url': 'https://example.com'},
     ]
     expected_links.extend(DEFAULT_LINKS)
 
     expected_headers = [
-        {'title': title, 'url': url},
+        {'title': 'Example', 'url': 'https://example.com'},
     ]
     expected_headers.extend(DEFAULT_HEADERS)
 
@@ -72,59 +72,46 @@ def test_add_link_to_custom_header(app):
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 def test_add_unsupported_link_to_custom_header(app):
-    title = 'example'
-    url = 'http://example.com'
     data = {
-        'new_title': title,
-        'new_link': url
+        'new_title': 'Bad Example',
+        'new_link': 'http://example.com'
     }
     response = do_post(app, ADD_LINK_TO_HEADER_URL, data, is_sysadmin=True)
-    check_custom_header_page_html(response,
-                                  links=[],
-                                  headers=DEFAULT_HEADERS)
+    check_custom_header_page_html(response, links=[], headers=DEFAULT_HEADERS)
 
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")
-def test_remove_link_to_custom_header(app):
+def test_remove_link_from_custom_header(app):
     data = {
-        'to_remove': 'Groups',
+        'to_remove': 'About',
     }
     expected_links = list(DEFAULT_LINKS)
-
-    expected_links.pop(2)
+    expected_links.pop(3)
 
     expected_headers = list(DEFAULT_HEADERS)
-    expected_headers.pop(2)
-
-    custom_header_response = do_get(app, CUSTOM_HEADER_URL, is_sysadmin=True)
-    check_custom_header_page_html(custom_header_response, links=[], headers=expected_headers, default_layout=True)
+    expected_headers.pop(3)
 
     response = do_post(app, REMOVE_LINK_FROM_HEADER_URL, data, is_sysadmin=True)
     check_custom_header_page_html(response, links=expected_links, headers=expected_headers)
-    assert 'Groups' not in response
+    assert '<li><a href="/about">About</a></li>' not in response
 
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 def test_update_multiple_custom_header_links(app):
     data = {
         'layout_type': 'default',
-        'position': ['2', '1', '0'],
-        'title': ['Datasets Updated', 'Organizations Updated', 'Groups Updated'],
-        'url': ['/dataset/', '/organization/', '/group/']
+        'position': ['1', '0'],
+        'title': ['Dataset Catalog', 'Departments'],
+        'url': ['/dataset', '/organization']
     }
     expected_links = (
-        {'position': 2, 'title': 'Datasets Updated', 'url': '/dataset/'},
-        {'position': 1, 'title': 'Organizations Updated', 'url': '/organization/'},
-        {'position': 0, 'title': 'Groups Updated', 'url': '/group/'}
+        {'position': 1, 'title': 'Dataset Catalog', 'url': '/dataset'},
+        {'position': 0, 'title': 'Departments', 'url': '/organization'}
     )
     expected_headers = (
-        {'title': 'Datasets Updated', 'url': '/dataset/'},
-        {'title': 'Organizations Updated', 'url': '/organization/'},
-        {'title': 'Groups Updated', 'url': '/group/'}
+        {'title': 'Dataset Catalog', 'url': '/dataset'},
+        {'title': 'Departments', 'url': '/organization'}
     )
-
-    custom_header_response = do_get(app, CUSTOM_HEADER_URL, is_sysadmin=True)
-    check_custom_header_page_html(custom_header_response, links=[], headers=list(DEFAULT_HEADERS), default_layout=True)
 
     response = do_post(app, CUSTOM_HEADER_URL, data, is_sysadmin=True)
     check_custom_header_page_html(response, links=expected_links, headers=expected_headers)
@@ -135,15 +122,12 @@ def test_update_single_custom_header_links(app):
     data = {
         'layout_type': 'compressed',
         'position': '0',
-        'title': 'Datasets Updated',
-        'url': '/dataset/'
+        'title': 'New Datasets',
+        'url': '/dataset'
     }
     expected_headers = [
-        {'title': 'Datasets Updated', 'url': '/dataset/'}
+        {'title': 'New Datasets', 'url': '/dataset'}
     ]
-
-    custom_header_response = do_get(app, CUSTOM_HEADER_URL, is_sysadmin=True)
-    check_custom_header_page_html(custom_header_response, links=[], headers=DEFAULT_HEADERS, default_layout=True)
 
     response = do_post(app, CUSTOM_HEADER_URL, data, is_sysadmin=True)
     check_custom_header_page_html(response, links=[], headers=expected_headers, default_layout=False)


### PR DESCRIPTION
## Description
This PR removes the use of DEFAULT_CONFIG_SECTION and Link object to simplify logic for custom header.
Also removes getting links for custom pages from build_pages_nav_main(). Instead we should manually add them through the custom header from.