### PR TITLE
Remove add/remove custom header link routes

### DIFF
--- a/ckanext/opendata_theme/opengov_custom_css/assets/css/theme.css
+++ b/ckanext/opendata_theme/opengov_custom_css/assets/css/theme.css
@@ -38,6 +38,10 @@
   margin-top: 2px;
   margin-bottom: 2px;
 }
+.masthead hgroup h2 {
+  bottom: 0px;
+  left: 15px;
+}
 .masthead .navbar-collapse {
   margin-top: 5px;
   padding: 0;

--- a/ckanext/opendata_theme/opengov_custom_css/processor.py
+++ b/ckanext/opendata_theme/opengov_custom_css/processor.py
@@ -13,7 +13,7 @@ class AccountHeaderBackGroundColor(AbstractParser):
     form_name = 'account-header-background-color'
     title = 'Account Header Background Color'
     location = 'background'
-    _default_value = '#044187'
+    _default_value = '#165cab'
 
 
 class AccountHeaderHoverBackgroundColor(AbstractParser):
@@ -37,7 +37,7 @@ class NavigationHeaderBackGroundColor(AbstractParser):
     form_name = 'nav-header-background-color'
     title = 'Navigation Header Background Color'
     location = 'background'
-    _default_value = '#1f76d8'
+    _default_value = '#ffffff'
 
 
 class NavigationHeaderHoverBackgroundColor(AbstractParser):
@@ -47,16 +47,18 @@ class NavigationHeaderHoverBackgroundColor(AbstractParser):
     form_name = 'nav-header-hover-background-color'
     title = 'Navigation Header Hover Background Color'
     location = 'background-color'
-    _default_value = '#044187'
+    _default_value = '#1f76d8'
 
 
 class NavigationHeaderTextColor(AbstractParser):
     class_name = ('.navbar .nav>li>a,'
-                  '.masthead .nav>li>a')
+                  '.masthead .nav>li>a,'
+                  '.navbar hgroup>h1>a,'
+                  '.navbar hgroup>h2')
     form_name = 'nav-header-text-color'
     title = 'Navigation Header Text Color'
     location = 'color'
-    _default_value = '#ffffff'
+    _default_value = '#07305c'
 
 
 class ModuleHeaderBackgroundColor(AbstractParser):
@@ -64,7 +66,7 @@ class ModuleHeaderBackgroundColor(AbstractParser):
     form_name = 'module-header-background-color'
     title = 'Side Menu Header Background Color'
     location = 'background'
-    _default_value = '#1f76d8'
+    _default_value = '#165cab'
 
 
 class ModuleHeaderTextColor(AbstractParser):
@@ -80,7 +82,7 @@ class FooterBackGroundColor(AbstractParser):
     form_name = 'footer-background-color'
     title = 'Footer Background Color'
     location = 'background'
-    _default_value = '#383b3d'
+    _default_value = '#07305c'
 
 
 class FooterLinkColor(AbstractParser):

--- a/ckanext/opendata_theme/opengov_custom_header/controller.py
+++ b/ckanext/opendata_theme/opengov_custom_header/controller.py
@@ -1,4 +1,6 @@
 # encoding: utf-8
+from copy import deepcopy
+
 import ckan.plugins.toolkit as tk
 from ckan import model
 
@@ -29,10 +31,22 @@ class CustomHeaderController(BaseCompatibilityController):
 
         if tk.request.method == 'POST':
             data = self.get_form_data(tk.request)
-            custom_header = {
-                'layout_type': data.get('layout_type', 'default'),
-                'links': []
-            }
+            if 'save' in data:
+                custom_header = self.save_link(data)
+            elif 'add_link' in data:
+                custom_header = self.add_link(data, custom_header)
+            elif 'remove_link' in data:
+                custom_header = self.remove_link(data, custom_header)
+
+        return tk.render('admin/custom_header_form.html',
+                         extra_vars=custom_header)
+
+    def save_link(self, data):
+        custom_header = {
+            'layout_type': data.get('layout_type', 'default'),
+            'links': []
+        }
+        try:
             if isinstance(data.get('url'), list):
                 for index in range(len(data.get('url'))):
                     custom_header['links'].append(
@@ -42,7 +56,7 @@ class CustomHeaderController(BaseCompatibilityController):
                             'url': data['url'][index]
                         }
                     )
-            else:
+            elif data.get('position') and data.get('title') and data.get('url'):
                 custom_header['links'].append(
                     {
                         'position': data['position'],
@@ -50,64 +64,48 @@ class CustomHeaderController(BaseCompatibilityController):
                         'url': data['url']
                     }
                 )
-            error = self.save_custom_header_metadata(custom_header)
-            custom_header['errors'] = error
-        return tk.render('admin/custom_header_form.html',
-                         extra_vars=custom_header)
+            errors = self.save_custom_header_metadata(custom_header)
+            custom_header['errors'] = errors
+        except tk.ValidationError as err:
+            custom_header['errors'] = err.error_dict
+        return custom_header
 
-    def add_link(self):
+    def add_link(self, data, old_header):
+        new_header = deepcopy(old_header)
+        new_header.get('links', []).append(
+            {
+                'position': len(new_header.get('links', [])),
+                'title': data.get('new_title'),
+                'url': data.get('new_url')
+            }
+        )
         try:
-            context = {'model': model, 'user': tk.c.user}
-            tk.check_access('sysadmin', context, {})
-        except tk.NotAuthorized:
-            tk.abort(403, tk._('Need to be system administrator to administer'))
+            errors = self.save_custom_header_metadata(new_header)
+        except tk.ValidationError as err:
+            errors = err.error_dict
+        if errors:
+            old_header.update({
+                'errors': errors,
+                'new_title': data.get('new_title', ''),
+                'url': data.get('new_url', '')
+            })
+            return old_header
+        return new_header
 
-        if tk.request.method == 'POST':
-            data = self.get_form_data(tk.request)
-            header_data = self.get_custom_header_metadata()
-            header_data.get('links', []).append(
-                {
-                    'position': len(header_data.get('links', [])),
-                    'title': data.get('new_title'),
-                    'url': data.get('new_url')
-                }
-            )
-            error = self.save_custom_header_metadata(header_data)
-            header_data['errors'] = error
-            return tk.render('admin/custom_header_form.html',
-                             extra_vars=header_data)
-
-        if tk.check_ckan_version(min_version='2.9.0'):
-            custom_header_route = 'custom-header.custom_header'
-        else:
-            custom_header_route = 'custom_header'
-        return tk.redirect_to(custom_header_route)
-
-    def remove_link(self):
+    def remove_link(self, data, old_header):
+        new_header = deepcopy(old_header)
         try:
-            context = {'model': model, 'user': tk.c.user}
-            tk.check_access('sysadmin', context, {})
-        except tk.NotAuthorized:
-            tk.abort(403, tk._('Need to be system administrator to administer'))
-
-        if tk.request.method == 'POST':
-            data = self.get_form_data(tk.request)
-            header_data = self.get_custom_header_metadata()
-            item = [link for link in header_data['links'] if link.get('title') == data['to_remove']]
-            try:
-                header_data['links'].remove(item[0])
-                error = self.save_custom_header_metadata(header_data)
-                header_data['errors'] = error
-            except IndexError:
-                header_data['errors'] = "Unable to remove link."
-            return tk.render('admin/custom_header_form.html',
-                             extra_vars=header_data)
-
-        if tk.check_ckan_version(min_version='2.9.0'):
-            custom_header_route = 'custom-header.custom_header'
-        else:
-            custom_header_route = 'custom_header'
-        return tk.redirect_to(custom_header_route)
+            item = [link for link in new_header['links'] if link.get('title') == data['remove_title']]
+            new_header['links'].remove(item[0])
+            errors = self.save_custom_header_metadata(new_header)
+        except tk.ValidationError as err:
+            errors = err.error_dict
+        except IndexError:
+            errors = {'Remove Nav Link': 'No link to remove.'}
+        if errors:
+            old_header['errors'] = errors
+            return old_header
+        return new_header
 
     def reset_custom_header(self):
         try:
@@ -127,8 +125,8 @@ class CustomHeaderController(BaseCompatibilityController):
     def save_custom_header_metadata(self, custom_header):
         try:
             CustomHeaderController.store_data(CONFIG_SECTION, custom_header)
-        except tk.ValidationError as ex:
-            return ex.error_summary
+        except tk.ValidationError as err:
+            return err.error_summary or err.error_dict
 
     def get_custom_header_metadata(self):
         data_dict = CustomHeaderController.get_data(CONFIG_SECTION)

--- a/ckanext/opendata_theme/opengov_custom_header/plugin/flask_plugin.py
+++ b/ckanext/opendata_theme/opengov_custom_header/plugin/flask_plugin.py
@@ -18,7 +18,3 @@ og_header.add_url_rule('/custom_header', methods=['GET', 'POST'],
                        view_func=CustomHeaderController().custom_header)
 og_header.add_url_rule('/reset_custom_header', methods=['GET', 'POST'],
                        view_func=CustomHeaderController().reset_custom_header)
-og_header.add_url_rule('/add_link_to_header', methods=['POST'],
-                       view_func=CustomHeaderController().add_link)
-og_header.add_url_rule('/remove_link_from_header', methods=['POST'],
-                       view_func=CustomHeaderController().remove_link)

--- a/ckanext/opendata_theme/opengov_custom_header/plugin/pylons_plugin.py
+++ b/ckanext/opendata_theme/opengov_custom_header/plugin/pylons_plugin.py
@@ -24,14 +24,4 @@ class MixinPlugin(p.SingletonPlugin):
             '/ckan-admin/reset_custom_header',
             action='reset_custom_header', controller=controller
         )
-        m.connect(
-            'add_link_to_header',
-            '/ckan-admin/add_link_to_header',
-            action='add_link', controller=controller
-        )
-        m.connect(
-            'remove_link_from_header',
-            '/ckan-admin/remove_link_from_header',
-            action='remove_link', controller=controller
-        )
         return m

--- a/ckanext/opendata_theme/opengov_custom_header/templates/admin/custom_header_form.html
+++ b/ckanext/opendata_theme/opengov_custom_header/templates/admin/custom_header_form.html
@@ -4,25 +4,15 @@
 
 {% if h.version(h.ckan_version()) < h.version('2.9') %}
     {% set custom_header_action = h.url_for(
-    controller='ckanext.opendata_theme.opengov_custom_header.controller:CustomHeaderController',
-    action='custom_header') %}
+       controller='ckanext.opendata_theme.opengov_custom_header.controller:CustomHeaderController',
+       action='custom_header') %}
 
     {% set reset_custom_header = h.url_for(
-    controller='ckanext.opendata_theme.opengov_custom_header.controller:CustomHeaderController',
-    action='reset_custom_header') %}
-
-    {% set remove_link_from_custom_header = h.url_for(
-    controller='ckanext.opendata_theme.opengov_custom_header.controller:CustomHeaderController',
-    action='remove_link') %}
-
-    {% set add_link_from_custom_header = h.url_for(
-    controller='ckanext.opendata_theme.opengov_custom_header.controller:CustomHeaderController',
-    action='add_link') %}
+       controller='ckanext.opendata_theme.opengov_custom_header.controller:CustomHeaderController',
+       action='reset_custom_header') %}
 {% else %}
     {% set custom_header_action = h.url_for('/ckan-admin/custom_header') %}
     {% set reset_custom_header = h.url_for('/ckan-admin/reset_custom_header') %}
-    {% set remove_link_from_custom_header = h.url_for('/ckan-admin/remove_link_from_header') %}
-    {% set add_link_from_custom_header = h.url_for('/ckan-admin/add_link_to_header') %}
 {% endif %}
 
 
@@ -41,6 +31,9 @@
         </div>
         <hr>
         <h4>Current Navigation Links</h4>
+        {% if not links %}
+            <p>No navigation links currently set.</p>
+        {% endif %}
         {% for link in links %}
             <div class="form-group control-group">
                 <div class="row" id="{{ 'link-%d' % loop.index0 }}">
@@ -66,7 +59,7 @@
         {% endfor %}
     </form>
     <hr>
-    <form method="post" action="{{ add_link_from_custom_header }}">
+    <form method="post" action="{{ custom_header_action }}">
         <h4>Add Navigation Link</h4>
         <div class="form-group control-group control-custom">
             <div class="controls editor">
@@ -74,42 +67,44 @@
                     <div class="col-sm-5 span5">
                         <div class="input-group">
                             <label class="input-group-addon" for="new_title">Title</label>
-                            <input class="form-control" type="text" id="new_title" name="new_title"/>
+                            <input class="form-control" type="text" id="new_title" name="new_title" value="{{ new_title }}"/>
                         </div>
                     </div>
                     <div class="col-sm-5 span5">
                         <div class="input-group">
                             <label class="input-group-addon" for="new_url">URL</label>
-                            <input class="form-control" type="text" id="new_url" name="new_url"/>
+                            <input class="form-control" type="text" id="new_url" name="new_url" value="{{ new_url }}"/>
                         </div>
                     </div>
-                    <button class="btn btn-default" name="add" type="submit">{{ _('Add') }}</button>
+                    <button class="btn btn-default" name="add_link" type="submit">{{ _('Add') }}</button>
                 </div>
             </div>
         </div>
     </form>
     <hr>
-    <form method="post" action="{{ remove_link_from_custom_header }}">
-        <h4>Remove Navigation Link</h4>
-        <div class="form-group control-group control-custom">
-            <div class="controls editor">
-                <div class="row">
-                    <div class="col-sm-5 span5">
-                        <div class="input-group">
-                            <label class="input-group-addon" for="to_remove">Title (URL)</label>
-                            <select class="form-control" name="to_remove">
-                                {% for link in links %}
-                                    <option value="{{ link.title }}">{{ link.title }} ( {{ link.url }} )</option>
-                                {% endfor %}
-                            </select>
+    {% if links %}
+        <form method="post" action="{{ custom_header_action }}">
+            <h4>Remove Navigation Link</h4>
+            <div class="form-group control-group control-custom">
+                <div class="controls editor">
+                    <div class="row">
+                        <div class="col-sm-5 span5">
+                            <div class="input-group">
+                                <label class="input-group-addon" for="remove_title">Title (URL)</label>
+                                <select class="form-control" name="remove_title">
+                                    {% for link in links %}
+                                        <option value="{{ link.title }}">{{ link.title }} ( {{ link.url }} )</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
                         </div>
+                        <button class="btn btn-default" name="remove_link" type="submit">{{ _('Remove') }}</button>
                     </div>
-                    <button class="btn btn-default" name="remove" type="submit">{{ _('Remove') }}</button>
                 </div>
             </div>
-        </div>
-    </form>
-    <hr>
+        </form>
+        <hr>
+    {% endif %}
     <div class="form-actions">
         <button class="btn btn-primary pull-right" name="save" type="submit" form="custom-header-form">{{ _('Update Config') }}</button>
         <a class="btn btn-danger pull-left" data-module="confirm-action"

--- a/ckanext/opendata_theme/opengov_custom_theme/templates/admin/config.html
+++ b/ckanext/opendata_theme/opengov_custom_theme/templates/admin/config.html
@@ -1,0 +1,36 @@
+{% ckan_extends %}
+
+{% block admin_form %}
+
+    {{ form.input('ckan.site_title', id='field-ckan-site-title', label=_('Site Title'), value=data['ckan.site_title'], error=error, classes=['control-medium']) }}
+
+    {{ form.input('ckan.site_description', id='field-ckan-site-description', label=_('Site Tag Line'), value=data['ckan.site_description'], error=error, classes=['control-medium']) }}
+
+    {% set field_url = 'ckan.site_logo' %}
+    {% set is_upload = data[field_url] and not data[field_url].startswith('http') %}
+    {% set is_url = data[field_url] and data[field_url].startswith('http') %}
+    {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload, upload_label = _('Site logo'), url_label=_('Site logo'),  field_url=field_url, field_upload='logo_upload', field_clear='clear_logo_upload' )}}
+
+    {{ form.markdown('ckan.site_about', id='field-ckan-site-about', label=_('About'), value=data['ckan.site_about'], error=error, placeholder=_('About page text')) }}
+
+    {{ form.markdown('ckan.site_intro_text', id='field-ckan-site-intro-text', label=_('Intro Text'), value=data['ckan.site_intro_text'], error=error, placeholder=_('Text on home page')) }}
+
+{% endblock %}
+
+{% block admin_form_help %}
+    {% set about_url = h.url_for(controller='home', action='about') %}
+    {% set home_url = h.url_for(controller='home', action='index') %}
+    {% set docs_url = "http://docs.ckan.org/en/{0}/theming".format(g.ckan_doc_version) %}
+    {% trans %}
+        <p><strong>Site Title:</strong> This is the title of this site,
+            which appears in various places throughout the site.</p>
+        <p><strong>Site Tag Line:</strong> This is the text that appears in the header
+            below the site title if no logo is present.</p>
+        <p><strong>Site Tag Logo:</strong> This is the logo that appears in the header.
+            If this field is empty, the site title and tag line will appear instead.</p>
+        <p><strong>About:</strong> This text will appear on this site's
+            <a href="{{ about_url }}">about page</a>.</p>
+        <p><strong>Intro Text:</strong> This text will appear on this site's
+            <a href="{{ home_url }}">home page</a> as a welcome message to visitors.</p>
+    {% endtrans %}
+{% endblock %}

--- a/ckanext/opendata_theme/tests/opengov_custom_css/test_custom_css.py
+++ b/ckanext/opendata_theme/tests/opengov_custom_css/test_custom_css.py
@@ -6,29 +6,29 @@ CUSTOM_CSS_URL = "/ckan-admin/custom_css"
 RESET_CUSTOM_CSS_URL = "/ckan-admin/reset_custom_css"
 
 DEFAULT_DATA = {
-    'account-header-background-color': '#044187',
+    'account-header-background-color': '#165cab',
     'account-header-hover-background-color': '#1f76d8',
     'account-header-text-color': '#ffffff',
-    'nav-header-background-color': '#1f76d8',
-    'nav-header-hover-background-color': '#044187',
-    'nav-header-text-color': '#ffffff',
-    'module-header-background-color': '#1f76d8',
+    'nav-header-background-color': '#ffffff',
+    'nav-header-hover-background-color': '#1f76d8',
+    'nav-header-text-color': '#07305c',
+    'module-header-background-color': '#165cab',
     'module-header-text-color': '#ffffff',
-    'footer-background-color': '#383b3d',
+    'footer-background-color': '#07305c',
     'footer-link-text-color': '#ffffff',
     'footer-text-color': '#ffffff'
 }
 
 DEFAULT_CUSTOM_CSS = (
-    '.account-masthead {background: #044187}',
+    '.account-masthead {background: #165cab}',
     '.account-masthead .account ul li a:hover {background: #1f76d8}',
     '.account-masthead .account ul li a {color: #ffffff}',
-    '.masthead {background: #1f76d8}',
+    '.masthead {background: #ffffff}',
     '.masthead .navigation .nav-pills li a:hover,.masthead .navigation .nav-pills li.active a,'
-    '.navbar-toggle {background-color: #044187}',
-    '.navbar .nav>li>a,.masthead .nav>li>a {color: #ffffff}',
-    '.module-heading {background: #1f76d8; color: #ffffff}',
-    'body, .site-footer {background: #383b3d}',
+    '.navbar-toggle {background-color: #1f76d8}',
+    '.navbar .nav>li>a,.masthead .nav>li>a,.navbar hgroup>h1>a,.navbar hgroup>h2 {color: #07305c}',
+    '.module-heading {background: #165cab; color: #ffffff}',
+    'body, .site-footer {background: #07305c}',
     '.site-footer a,.site-footer a:hover {color: #ffffff}',
     '.site-footer,.site-footer label,.site-footer small {color: #ffffff}'
 )
@@ -64,11 +64,11 @@ def test_get_custom_css_page_with_default_data(app):
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 def test_post_custom_css_page_with_changed_color(app):
     data = DEFAULT_DATA.copy()
-    data['account-header-background-color'] = '#044189'
-    unexpected_custom_css = '.account-masthead {background: #044187}'
+    data['account-header-background-color'] = '#07305c'
+    unexpected_custom_css = '.account-masthead {background: #165cab}'
     expected_custom_css = list(DEFAULT_CUSTOM_CSS)
     expected_custom_css.remove(unexpected_custom_css)
-    expected_custom_css.append('.account-masthead {background: #044189}')
+    expected_custom_css.append('.account-masthead {background: #07305c}')
     response = do_post(app, CUSTOM_CSS_URL, is_sysadmin=True, data=data)
 
     check_custom_css_page_html(response, expected_form_data=data, expected_css_data=expected_custom_css)
@@ -96,11 +96,11 @@ def test_post_custom_css_page_with_changed_color_respond_with_contrast_connected
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 def test_reset_changed_custom_css(app):
     data = DEFAULT_DATA.copy()
-    data['account-header-background-color'] = '#044189'
-    unexpected_custom_css = '.account-masthead {background: #044187}'
+    data['account-header-background-color'] = '#07305c'
+    unexpected_custom_css = '.account-masthead {background: #165cab}'
     expected_custom_css = list(DEFAULT_CUSTOM_CSS)
     expected_custom_css.remove(unexpected_custom_css)
-    expected_custom_css.append('.account-masthead {background: #044189}')
+    expected_custom_css.append('.account-masthead {background: #07305c}')
     response = do_post(app, CUSTOM_CSS_URL, is_sysadmin=True, data=data)
     assert unexpected_custom_css not in response
 

--- a/ckanext/opendata_theme/tests/opengov_custom_header/test_custom_header.py
+++ b/ckanext/opendata_theme/tests/opengov_custom_header/test_custom_header.py
@@ -4,8 +4,6 @@ from ckanext.opendata_theme.tests.helpers import do_get, do_post
 
 CUSTOM_HEADER_URL = "/ckan-admin/custom_header"
 RESET_CUSTOM_HEADER_URL = "/ckan-admin/reset_custom_header"
-ADD_LINK_TO_HEADER_URL = "/ckan-admin/add_link_to_header"
-REMOVE_LINK_FROM_HEADER_URL = "/ckan-admin/remove_link_from_header"
 DEFAULT_LINKS = (
     {'position': 0, 'title': 'Datasets', 'url': '/dataset'},
     {'position': 1, 'title': 'Organizations', 'url': '/organization'},
@@ -50,6 +48,7 @@ def test_get_custom_header_page(app):
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 def test_add_link_to_custom_header(app):
     data = {
+        'add_link': '',
         'new_title': 'Example',
         'new_url': 'https://example.com',
     }
@@ -59,24 +58,26 @@ def test_add_link_to_custom_header(app):
     custom_header_response = do_get(app, CUSTOM_HEADER_URL, is_sysadmin=True)
     check_custom_header_page_html(custom_header_response, links=[], headers=DEFAULT_HEADERS, default_layout=True)
 
-    response = do_post(app, ADD_LINK_TO_HEADER_URL, data, is_sysadmin=True)
+    response = do_post(app, CUSTOM_HEADER_URL, data, is_sysadmin=True)
     check_custom_header_page_html(response, links=expected_links, headers=expected_headers)
 
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 def test_add_unsupported_link_to_custom_header(app):
     data = {
+        'add_link': '',
         'new_title': 'Bad Example',
         'new_link': 'http://example.com'
     }
-    response = do_post(app, ADD_LINK_TO_HEADER_URL, data, is_sysadmin=True)
+    response = do_post(app, CUSTOM_HEADER_URL, data, is_sysadmin=True)
     check_custom_header_page_html(response, links=[], headers=DEFAULT_HEADERS)
 
 
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 def test_remove_link_from_custom_header(app):
     data = {
-        'to_remove': 'About',
+        'remove_link': '',
+        'remove_title': 'About',
     }
     expected_links = list(DEFAULT_LINKS)
     expected_links.pop(3)
@@ -84,7 +85,7 @@ def test_remove_link_from_custom_header(app):
     expected_headers = list(DEFAULT_HEADERS)
     expected_headers.pop(3)
 
-    response = do_post(app, REMOVE_LINK_FROM_HEADER_URL, data, is_sysadmin=True)
+    response = do_post(app, CUSTOM_HEADER_URL, data, is_sysadmin=True)
     check_custom_header_page_html(response, links=expected_links, headers=expected_headers)
     assert '<li><a href="/about">About</a></li>' not in response
 
@@ -92,6 +93,7 @@ def test_remove_link_from_custom_header(app):
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 def test_update_multiple_custom_header_links(app):
     data = {
+        'save': '',
         'layout_type': 'default',
         'position': ['1', '0'],
         'title': ['Dataset Catalog', 'Departments'],
@@ -113,6 +115,7 @@ def test_update_multiple_custom_header_links(app):
 @pytest.mark.usefixtures("clean_db", "with_request_context")
 def test_update_single_custom_header_links(app):
     data = {
+        'save': '',
         'layout_type': 'compressed',
         'position': '0',
         'title': 'New Datasets',


### PR DESCRIPTION
## Description
Remove add/remove custom header link routes so that users are redirected away from the custom header form.
Also:
- Update the default values for custom CSS
- Display a message if no nav links are set
- Hide remove link form id no nav links are set
- Hide the Custom CSS and Homepage fields from the default sysadmin config form