### PR TITLE
Add spatial widget to dataset search

### DIFF
--- a/ckanext/opendata_theme/base/helpers.py
+++ b/ckanext/opendata_theme/base/helpers.py
@@ -224,10 +224,12 @@ def value_should_be_shorter_than_length(field_name='Field', length=30):
         def _wrap(value):
             if len(value) > length:
                 raise toolkit.Invalid(
-                    '{} is too long. Maximum {} characters allowed for {}'.format(field_name, length, value))
+                    '{} is too long. Maximum {} characters allowed for {}'.format(field_name, length, value)
+                )
             return func(value)
         return _wrap
     return decorator
+
 
 def get_default_extent():
     """
@@ -237,5 +239,7 @@ def get_default_extent():
     return config.get(
         'ckanext.spatial.default_extent',
         '{ "type": "Polygon", \
-           "coordinates": [[[-124.7844079,24.7433195],[-66.9513812,24.7433195],[-66.9513812,49.3457868],[-124.7844079,49.3457868],[-124.7844079,24.7433195]]] }'
+           "coordinates": [[[-124.7844079,24.7433195], \
+            [-66.9513812,24.7433195],[-66.9513812,49.3457868], \
+            [-124.7844079,49.3457868],[-124.7844079,24.7433195]]] }'
     )

--- a/ckanext/opendata_theme/base/helpers.py
+++ b/ckanext/opendata_theme/base/helpers.py
@@ -119,7 +119,7 @@ def get_custom_name(key, default_name):
     if not name:
         return default_name
     else:
-        return toolkit.h.render_markdown(name.get('value', default_name))
+        return toolkit.h.markdown_extract(name.get('value', default_name))
 
 
 def get_data(key):
@@ -228,3 +228,14 @@ def value_should_be_shorter_than_length(field_name='Field', length=30):
             return func(value)
         return _wrap
     return decorator
+
+def get_default_extent():
+    """
+    Return default extent to use with spatial widget
+    If none is configured a bounding box of the continental US is returned
+    """
+    return config.get(
+        'ckanext.spatial.default_extent',
+        '{ "type": "Polygon", \
+           "coordinates": [[[-124.7844079,24.7433195],[-66.9513812,24.7433195],[-66.9513812,49.3457868],[-124.7844079,49.3457868],[-124.7844079,24.7433195]]] }'
+    )

--- a/ckanext/opendata_theme/opengov_custom_css/processor.py
+++ b/ckanext/opendata_theme/opengov_custom_css/processor.py
@@ -70,7 +70,8 @@ class ModuleHeaderBackgroundColor(AbstractParser):
 
 
 class ModuleHeaderTextColor(AbstractParser):
-    class_name = '.module-heading'
+    class_name = ('.module-heading,'
+                  '.module-heading .action')
     form_name = 'module-header-text-color'
     title = 'Side Menu Header Text Color'
     location = 'color'

--- a/ckanext/opendata_theme/opengov_custom_theme/plugin.py
+++ b/ckanext/opendata_theme/opengov_custom_theme/plugin.py
@@ -17,5 +17,6 @@ class OpenDataThemePlugin(plugins.SingletonPlugin):
         return {
             'opendata_theme_group_alias': helper.get_group_alias,
             'opendata_theme_organization_alias': helper.get_organization_alias,
+            'opendata_theme_get_default_extent': helper.get_default_extent,
             'version': helper.version_builder,
         }

--- a/ckanext/opendata_theme/opengov_custom_theme/templates/package/read_base.html
+++ b/ckanext/opendata_theme/opengov_custom_theme/templates/package/read_base.html
@@ -17,3 +17,13 @@
   {{ h.build_nav_icon('dataset_groups', _('{Groups}'.format(Groups=group_alias_pural)), id=pkg.name, icon='users') }}
   {{ h.build_nav_icon('dataset_activity', _('Activity Stream'), id=pkg.id if is_activity_archive else pkg.name, icon='clock-o') }}
 {% endblock %}
+
+{% block secondary_content %}
+  {{ super() }}
+
+  {% set dataset_extent = h.get_pkg_dict_extra(c.pkg_dict, 'spatial', '') %}
+  {% if dataset_extent %}
+    {% snippet "spatial/snippets/dataset_map_sidebar.html", extent=dataset_extent %}
+  {% endif %}
+
+{% endblock %}

--- a/ckanext/opendata_theme/opengov_custom_theme/templates/package/search.html
+++ b/ckanext/opendata_theme/opengov_custom_theme/templates/package/search.html
@@ -1,0 +1,10 @@
+{% ckan_extends %}
+
+{% block secondary_content %}
+  {% if 'spatial_query' in g.plugins %}
+    {% set dataset_extent = h.opendata_theme_get_default_extent() %}
+    {% snippet "spatial/snippets/spatial_query.html", default_extent=dataset_extent %}
+  {% endif %}
+
+  {{ super() }}
+{% endblock %}

--- a/ckanext/opendata_theme/tests/opengov_custom_css/test_custom_css.py
+++ b/ckanext/opendata_theme/tests/opengov_custom_css/test_custom_css.py
@@ -27,7 +27,8 @@ DEFAULT_CUSTOM_CSS = (
     '.masthead .navigation .nav-pills li a:hover,.masthead .navigation .nav-pills li.active a,'
     '.navbar-toggle {background-color: #1f76d8}',
     '.navbar .nav>li>a,.masthead .nav>li>a,.navbar hgroup>h1>a,.navbar hgroup>h2 {color: #07305c}',
-    '.module-heading, .module-heading .action {background: #165cab; color: #ffffff}',
+    '.module-heading {background: #165cab}',
+    '.module-heading,.module-heading .action {color: #ffffff}',
     'body, .site-footer {background: #07305c}',
     '.site-footer a,.site-footer a:hover {color: #ffffff}',
     '.site-footer,.site-footer label,.site-footer small {color: #ffffff}'

--- a/ckanext/opendata_theme/tests/opengov_custom_css/test_custom_css.py
+++ b/ckanext/opendata_theme/tests/opengov_custom_css/test_custom_css.py
@@ -27,7 +27,7 @@ DEFAULT_CUSTOM_CSS = (
     '.masthead .navigation .nav-pills li a:hover,.masthead .navigation .nav-pills li.active a,'
     '.navbar-toggle {background-color: #1f76d8}',
     '.navbar .nav>li>a,.masthead .nav>li>a,.navbar hgroup>h1>a,.navbar hgroup>h2 {color: #07305c}',
-    '.module-heading {background: #165cab; color: #ffffff}',
+    '.module-heading, .module-heading .action {background: #165cab; color: #ffffff}',
     'body, .site-footer {background: #07305c}',
     '.site-footer a,.site-footer a:hover {color: #ffffff}',
     '.site-footer,.site-footer label,.site-footer small {color: #ffffff}'


### PR DESCRIPTION
## Description
Add spatial widget to dataset search page.

Also makes the following changes:
- Display the spatial extent in a dataset side menu if spatial field is present in the dataset extras field
- Use `markdown_extract` instead of `render_markdown` to only get text for homepage titles, html tags are removed