### PR TITLE
Add css for homepage flex order

### DIFF
--- a/ckanext/opendata_theme/opengov_custom_footer/templates/custom_footer.html
+++ b/ckanext/opendata_theme/opengov_custom_footer/templates/custom_footer.html
@@ -11,10 +11,10 @@
       {% block footer_attribution %}
         <strong>{{ _('Powered by') }}</strong>
         <div class="og-links">
-          <a class="pull-left" target="_blank" href="https://opengov.com/?utm_campaign=Footer-Product-OpenData&utm_source=OpenGov&utm_medium=product&utm_term=PO-OGOV-1274&utm_content=logo">
+          <a class="pull-left" href="https://opengov.com/?utm_campaign=Footer-Product-OpenData&utm_source=OpenGov&utm_medium=product&utm_term=PO-OGOV-1274&utm_content=logo" target="_blank">
             <img src="/img/OpenGov_Logo.png" alt="OpenGov" height="25">
           </a>
-          <a class="hide-text ckan-footer-logo pull-right" href="https://ckan.org">CKAN</a>
+          <a class="hide-text ckan-footer-logo pull-right" href="https://ckan.org" target="_blank">CKAN</a>
         </div>
       {% endblock %}
       {% block footer_lang %}

--- a/ckanext/opendata_theme/opengov_custom_footer/templates/default_footer.html
+++ b/ckanext/opendata_theme/opengov_custom_footer/templates/default_footer.html
@@ -22,10 +22,10 @@
     {% block footer_attribution %}
       <strong>{{ _('Powered by') }}</strong>
       <div style="white-space:nowrap; padding-bottom:16px;">
-        <a class="pull-left" target="_blank" href="https://opengov.com/?utm_campaign=Footer-Product-OpenData&utm_source=OpenGov&utm_medium=product&utm_term=PO-OGOV-1274&utm_content=logo">
+        <a class="pull-left" href="https://opengov.com/?utm_campaign=Footer-Product-OpenData&utm_source=OpenGov&utm_medium=product&utm_term=PO-OGOV-1274&utm_content=logo" target="_blank">
           <img src="/img/OpenGov_Logo.png" alt="OpenGov" height="25">
         </a>
-        <a class="hide-text ckan-footer-logo" href="https://ckan.org" style="margin-left:144px;">CKAN</a>
+        <a class="hide-text ckan-footer-logo" href="https://ckan.org" target="_blank" style="margin-left:144px;">CKAN</a>
       </div>
     {% endblock %}
     {% block footer_lang %}

--- a/ckanext/opendata_theme/opengov_custom_homepage/public/css/layout1.css
+++ b/ckanext/opendata_theme/opengov_custom_homepage/public/css/layout1.css
@@ -31,6 +31,23 @@
 .featured-charts-wrap {
   background-color: #FFFFFF;
 }
+
+/*layout2 homepage flex order start*/
+.flex-container {
+  display: flex;
+  flex-direction: column;
+}
+.main-browse {
+  order: 1;
+}
+.main-featured {
+  order: 2;
+}
+.main-updates {
+  order: 3;
+}
+/*layout2 homepage flex order end*/
+
 @media (max-width: 767px) {
   a.browse-group {
     width: 140px;

--- a/ckanext/opendata_theme/opengov_custom_homepage/public/css/layout2.css
+++ b/ckanext/opendata_theme/opengov_custom_homepage/public/css/layout2.css
@@ -31,6 +31,23 @@
 .featured-charts-wrap {
   background-color: #EFF2F5;
 }
+
+/*layout2 homepage flex order start*/
+.flex-container {
+  display: flex;
+  flex-direction: column;
+}
+.main-browse {
+  order: 1;
+}
+.main-featured {
+  order: 2;
+}
+.main-updates {
+  order: 3;
+}
+/*layout2 homepage flex order end*/
+
 @media (max-width: 767px) {
   a.browse-group {
     width: 140px;

--- a/ckanext/opendata_theme/opengov_custom_homepage/templates/home/layout1.html
+++ b/ckanext/opendata_theme/opengov_custom_homepage/templates/home/layout1.html
@@ -5,24 +5,23 @@
     {% snippet 'home/snippets/hero_title.html' %}
   {% endif %}
 
-
-  {% block opendata_theme_groups %}
-    {% if h.opendata_theme_get_groups() %}
-      {% snippet 'home/snippets/groups.html' %}
-    {% endif %}
-  {% endblock %}
-
-
-  {% block opendata_theme_showcases %}
-    {% if 'showcase' in g.plugins %}
-      {% if h.opendata_theme_get_showcases() %}
-        {% snippet 'home/snippets/opendata_theme_showcase.html' %}
+  <div class="flex-container">
+    {% block opendata_theme_groups %}
+      {% if h.opendata_theme_get_groups() %}
+        {% snippet 'home/snippets/groups.html' %}
       {% endif %}
-    {% endif %}
-  {% endblock %}
+    {% endblock %}
 
+    {% block opendata_theme_showcases %}
+      {% if 'showcase' in g.plugins %}
+        {% if h.opendata_theme_get_showcases() %}
+          {% snippet 'home/snippets/opendata_theme_showcase.html' %}
+        {% endif %}
+      {% endif %}
+    {% endblock %}
 
-  {% block opendata_theme_datasets %}
-    {% snippet 'home/snippets/datasets.html' %}
-  {% endblock %}
+    {% block opendata_theme_datasets %}
+      {% snippet 'home/snippets/datasets.html' %}
+    {% endblock %}
+  </div>
 </div>

--- a/ckanext/opendata_theme/opengov_custom_homepage/templates/home/layout2.html
+++ b/ckanext/opendata_theme/opengov_custom_homepage/templates/home/layout2.html
@@ -32,24 +32,23 @@
     </div>
   </div>
 
-
-  {% block opendata_theme_groups %}
-    {% if h.opendata_theme_get_groups() %}
-      {% snippet 'home/snippets/groups.html' %}
-    {% endif %}
-  {% endblock %}
-
-
-  {% block opendata_theme_showcases %}
-    {% if 'showcase' in g.plugins %}
-      {% if h.opendata_theme_get_showcases() %}
-        {% snippet 'home/snippets/opendata_theme_showcase.html' %}
+  <div class="flex-container">
+    {% block opendata_theme_groups %}
+      {% if h.opendata_theme_get_groups() %}
+        {% snippet 'home/snippets/groups.html' %}
       {% endif %}
-    {% endif %}
-  {% endblock %}
+    {% endblock %}
 
+    {% block opendata_theme_showcases %}
+      {% if 'showcase' in g.plugins %}
+        {% if h.opendata_theme_get_showcases() %}
+          {% snippet 'home/snippets/opendata_theme_showcase.html' %}
+        {% endif %}
+      {% endif %}
+    {% endblock %}
 
-  {% block opendata_theme_datasets %}
-    {% snippet 'home/snippets/datasets.html' %}
-  {% endblock %}
+    {% block opendata_theme_datasets %}
+      {% snippet 'home/snippets/datasets.html' %}
+    {% endblock %}
+  </div>
 </div>

--- a/ckanext/opendata_theme/opengov_custom_theme/plugin.py
+++ b/ckanext/opendata_theme/opengov_custom_theme/plugin.py
@@ -1,3 +1,5 @@
+from six import text_type
+
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 
@@ -11,6 +13,17 @@ class OpenDataThemePlugin(plugins.SingletonPlugin):
     # IConfigurer
     def update_config(self, ckan_config):
         toolkit.add_template_directory(ckan_config, 'templates')
+
+    def update_config_schema(self, schema):
+        ignore_missing = toolkit.get_validator('ignore_missing')
+        ignore_not_sysadmin = toolkit.get_validator('ignore_not_sysadmin')
+
+        schema.update({
+            # This is a custom configuration option
+            'contact_form_legend_content': [ignore_missing, ignore_not_sysadmin, text_type]
+        })
+
+        return schema
 
     # ITemplateHelpers
     def get_helpers(self):

--- a/ckanext/opendata_theme/opengov_custom_theme/templates/admin/config.html
+++ b/ckanext/opendata_theme/opengov_custom_theme/templates/admin/config.html
@@ -1,5 +1,7 @@
 {% ckan_extends %}
 
+{% import 'macros/form.html' as form %}
+
 {% block admin_form %}
 
     {{ form.input('ckan.site_title', id='field-ckan-site-title', label=_('Site Title'), value=data['ckan.site_title'], error=error, classes=['control-medium']) }}
@@ -14,6 +16,10 @@
     {{ form.markdown('ckan.site_about', id='field-ckan-site-about', label=_('About'), value=data['ckan.site_about'], error=error, placeholder=_('About page text')) }}
 
     {{ form.markdown('ckan.site_intro_text', id='field-ckan-site-intro-text', label=_('Intro Text'), value=data['ckan.site_intro_text'], error=error, placeholder=_('Text on home page')) }}
+
+    {% if 'contact' in g.plugins %}
+        {{ form.markdown('contact_form_legend_content', id='field-contact-form-legend-content', label=_('Contact Form Text'), value=data['contact_form_legend_content'], error=errors['contact_form_legend_content']) }}
+    {% endif %}
 
 {% endblock %}
 
@@ -33,4 +39,8 @@
         <p><strong>Intro Text:</strong> This text will appear on this site's
             <a href="{{ home_url }}">home page</a> as a welcome message to visitors.</p>
     {% endtrans %}
+    {% if 'contact' in g.plugins %}
+        <p><strong>Contact Form Text:</strong> This text will appear on this site's
+            <a href="/contact">contact page</a>.</p>
+    {% endif %}
 {% endblock %}

--- a/ckanext/opendata_theme/opengov_custom_theme/templates/contact/snippets/form.html
+++ b/ckanext/opendata_theme/opengov_custom_theme/templates/contact/snippets/form.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{% block contact_form_legend_content %}
+  {% if g.contact_form_legend_content %}
+    {{ h.render_markdown(g.contact_form_legend_content) }}
+  {% else %}
+    {{ _('Questions? Comments? We are always glad to hear from you!') }}
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Description
This PR makes the following changes:
- Add flex order to homepage layouts 1 and 2. This allows sysadmins to reorder the group, showcase, and dataset sections on the homepage with CSS
- Add config to allow sysadmins to add custom markdown text that will appear on the contact page
- Update the CKAN attribution footer link to open in a new tab (target="_blank")