### PR TITLE
Add check for spatial plugin for dataset extent snippet

### DIFF
--- a/ckanext/opendata_theme/opengov_custom_theme/templates/package/read_base.html
+++ b/ckanext/opendata_theme/opengov_custom_theme/templates/package/read_base.html
@@ -22,7 +22,7 @@
   {{ super() }}
 
   {% set dataset_extent = h.get_pkg_dict_extra(c.pkg_dict, 'spatial', '') %}
-  {% if dataset_extent %}
+  {% if 'spatial_metadata' in g.plugins and dataset_extent %}
     {% snippet "spatial/snippets/dataset_map_sidebar.html", extent=dataset_extent %}
   {% endif %}
 


### PR DESCRIPTION
## Description
Add check for spatial plugin for dataset extent snippet.
This fixes an error when the spatial plugin is not enabled.