### PR TITLE
Link to custom page for API doc in CNRA theme

### DIFF
--- a/ckanext/opendata_theme/extended_themes/cnra/templates/package/search.html
+++ b/ckanext/opendata_theme/extended_themes/cnra/templates/package/search.html
@@ -8,3 +8,20 @@
     </p>
   {% endif %}
 {% endblock %}
+
+{% block package_search_results_api_inner %}
+<small>
+  {% set api_link = h.link_to(_('API'), '/pages/api') %}
+  {% set api_doc_link = h.link_to(_('API Docs'), 'http://docs.ckan.org/en/{0}/api/'.format(g.ckan_doc_version)) %}
+  {% if g.dumps_url -%}
+    {% set dump_link = h.link_to(_('full {format} dump').format(format=g.dumps_format), g.dumps_url) %}
+    {% trans %}
+      You can also access this registry using the {{ api_link }} (see {{ api_doc_link }}) or download a {{ dump_link }}.
+    {% endtrans %}
+  {% else %}
+    {% trans %}
+      You can also access this registry using the {{ api_link }} (see {{ api_doc_link}}).
+    {% endtrans %}
+  {%- endif %}
+</small>
+{% endblock %}


### PR DESCRIPTION
## Description
Add link to `/pages/api` for API doc in CNRA theme