### PR TITLE
[OD-2376] Hide Profile image upload for public user registration and …

### DIFF
--- a/ckanext/opendata_theme/extended_themes/bostonma/assets/css/custom.css
+++ b/ckanext/opendata_theme/extended_themes/bostonma/assets/css/custom.css
@@ -52,6 +52,13 @@ a[href^="/datastore/dictionary_download/"] {
 .js .image-upload #field-image-upload {
   height: 100%;
 }
+
+/* hidden only for public user registration/edit */
+#user-register-form .image-upload,
+#user-edit-form .image-upload {
+  display: none !important;
+}
+
 a {
   color: #10497C;
   font-family: "Montserrat", sans-serif;

--- a/ckanext/opendata_theme/opengov_custom_css/assets/css/theme.css
+++ b/ckanext/opendata_theme/opengov_custom_css/assets/css/theme.css
@@ -392,3 +392,9 @@ form.form-inline.form-select.lang-select {
 .site-footer .ckan-footer-logo {
   margin-left: 20px;
 }
+
+/* hidden only for public user registration/edit */
+#user-register-form .image-upload,
+#user-edit-form .image-upload {
+  display: none !important;
+}


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [Update ckanext-opendata_theme to hide form to upload/link image](https://opengovinc.atlassian.net/browse/OD-2376)

## Description
Hide the inputs on user registration and edit forms

## Test Procedure
Tested locally

## Approval Criteria 
Picture upload button shouldn't appear:

![Screenshot 2024-03-12 at 9 15 55 AM](https://github.com/OpenGov-OpenData/ckanext-opendata_theme/assets/162158563/a88639a5-7706-4832-93d4-eda98f38001f)

## Submitter Checklist
- [x] The code looks good to me (LGTM)
- [x] I have tested the changes locally
- [x] The new changes does not affect web accessibility
