### PR TITLE
Fix featured view for CDT theme

### DIFF
--- a/ckanext/opendata_theme/extended_themes/cademo/templates/package/read.html
+++ b/ckanext/opendata_theme/extended_themes/cademo/templates/package/read.html
@@ -2,10 +2,22 @@
 
 {% block package_description %}
   {{ super() }}
+
   {% set arcgis_link = h.opendata_theme_get_arcgis_link(pkg.resources) %}
   {% if arcgis_link %}
     <a href="{{ arcgis_link }}" class="btn btn-primary" target="_blank">
       <i class="fa fa-map"></i> MAP
     </a>
+  {% endif %}
+
+  {% if 'featuredviews' in g.plugins %}
+    {% set view = h.get_canonical_resource_view(pkg.id) %}
+    {% if view %}
+      {% snippet 'package/snippets/resource_view.html',
+          resource_view = view['resource_view'],
+          resource = view['resource'],
+          package = pkg
+      %}
+    {% endif %}
   {% endif %}
 {% endblock %}

--- a/ckanext/opendata_theme/extended_themes/cnra/templates/package/read.html
+++ b/ckanext/opendata_theme/extended_themes/cnra/templates/package/read.html
@@ -2,7 +2,7 @@
 
 {% block primary_content_inner %}
   {% if 'featuredviews' in g.plugins %}
-  {% set view = h.get_canonical_resource_view(pkg.id) %}
+    {% set view = h.get_canonical_resource_view(pkg.id) %}
     {% if view %}
       {% snippet 'package/snippets/resource_view.html',
           resource_view = view['resource_view'],


### PR DESCRIPTION
# Description
Fix featured view for CDT theme. CDT's theme had a custom button for ArcGIS datasets, which conflicted with the Canonical View embed.