### PR TITLE
Sunday bugfixing

### DIFF
--- a/ckanext/opendata_theme/base/helpers.py
+++ b/ckanext/opendata_theme/base/helpers.py
@@ -106,7 +106,7 @@ def get_user_uuid():
     if c.user:
         user = c.userobj
         try:
-            user_token = model.Session.query(model.UserToken).filter(model.UserToken.email == user.email).first()
+            user_token = model.Session.query(model.UserToken).filter(model.UserToken.user_name == user.email).first()
             if user_token:
                 return user_token.platform_uuid
             return None

--- a/ckanext/opendata_theme/opengov_custom_theme/templates/user/dashboard.html
+++ b/ckanext/opendata_theme/opengov_custom_theme/templates/user/dashboard.html
@@ -33,7 +33,7 @@
     </header>
     <script>
       var userplatformuuid = "{{ h.opendata_theme_platform_uuid() }}";
-      analytics.identify(userplatformuuid || ' {{user.id}} ', {
+      analytics.identify(userplatformuuid || '{{user.id}}', {
         name: '{{user.fullname}}',
         email: '{{user.email}}'
       });


### PR DESCRIPTION
I was using the email column to get the token from the database, but that column doesn't exist in the token table... it is "user_name"

![image](https://github.com/user-attachments/assets/4658ec89-18b8-4055-8a83-08940eb5d6b7)


also removed extra spaces on the id html var