### PR TITLE
added group call to segment

### DIFF
--- a/ckanext/opendata_theme/base/helpers.py
+++ b/ckanext/opendata_theme/base/helpers.py
@@ -143,6 +143,10 @@ def get_segment_writekey():
     return str(config.get('ckan.segment_writekey', ''))
 
 
+def get_entity_id():
+    return str(config.get('ckanext.opengov.datastore.entity_id', 'controlpanel'))
+
+
 def get_group_alias():
     return str(config.get('ckan.group_alias', 'Group'))
 

--- a/ckanext/opendata_theme/opengov_custom_theme/plugin.py
+++ b/ckanext/opendata_theme/opengov_custom_theme/plugin.py
@@ -35,7 +35,8 @@ class OpenDataThemePlugin(plugins.SingletonPlugin):
             'opendata_theme_is_data_dict_active': helper.is_data_dict_active,
             'version': helper.version_builder,
             'opendata_theme_segment_writekey': helper.get_segment_writekey,
-            'opendata_theme_platform_uuid': helper.get_user_uuid
+            'opendata_theme_platform_uuid': helper.get_user_uuid,
+            'opendata_theme_entity': helper.get_entity_id
         }
 
     # IBlueprint

--- a/ckanext/opendata_theme/opengov_custom_theme/templates/base.html
+++ b/ckanext/opendata_theme/opengov_custom_theme/templates/base.html
@@ -10,10 +10,12 @@
         analytics.page();
         var entityid = "{{ h.opendata_theme_entity() }}";
         analytics.group(entityid)
-        if (window.location.pathname.endsWith("dashboard/")) {
-          var userplatformuuid = "{{ h.opendata_theme_platform_uuid() }}";
-          analytics.identify(userplatformuuid || '{{user.id}}', {name: '{{user.fullname}}', email: '{{user.email}}'});
-        }
+        {% if user %}
+          if (window.location.pathname.endsWith("dashboard/")) {
+            var userplatformuuid = "{{ h.opendata_theme_platform_uuid() }}";
+            analytics.identify(userplatformuuid || '{{user.id}}', {name: '{{user.fullname}}', email: '{{user.email}}'});
+          }
+        {% endif %}
       }}();
     }
   </script>

--- a/ckanext/opendata_theme/opengov_custom_theme/templates/base.html
+++ b/ckanext/opendata_theme/opengov_custom_theme/templates/base.html
@@ -6,8 +6,14 @@
     var writeKey = "{{ h.opendata_theme_segment_writekey() }}";
     if(writeKey !== ""){
       !function(){var i="analytics",analytics=window[i]=window[i]||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","screen","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware","register"];analytics.factory=function(e){return function(){if(window[i].initialized)return window[i][e].apply(window[i],arguments);var n=Array.prototype.slice.call(arguments);if(["track","screen","alias","group","page","identify"].indexOf(e)>-1){var c=document.querySelector("link[rel='canonical']");n.push({__t:"bpc",c:c&&c.getAttribute("href")||void 0,p:location.pathname,u:location.href,s:location.search,t:document.title,r:document.referrer})}n.unshift(e);analytics.push(n);return analytics}};for(var n=0;n<analytics.methods.length;n++){var key=analytics.methods[n];analytics[key]=analytics.factory(key)}analytics.load=function(key,n){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.setAttribute("data-global-segment-analytics-key",i);t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var r=document.getElementsByTagName("script")[0];r.parentNode.insertBefore(t,r);analytics._loadOptions=n};analytics._writeKey=writeKey;;analytics.SNIPPET_VERSION="5.2.0";
-      analytics.load(writeKey);
-      analytics.page();
+        analytics.load(writeKey);
+        analytics.page();
+        var entityid = "{{ h.opendata_theme_entity() }}";
+        analytics.group(entityid)
+        if (window.location.pathname.endsWith("dashboard/")) {
+          var userplatformuuid = "{{ h.opendata_theme_platform_uuid() }}";
+          analytics.identify(userplatformuuid || '{{user.id}}', {name: '{{user.fullname}}', email: '{{user.email}}'});
+        }
       }}();
     }
   </script>

--- a/ckanext/opendata_theme/opengov_custom_theme/templates/user/dashboard.html
+++ b/ckanext/opendata_theme/opengov_custom_theme/templates/user/dashboard.html
@@ -31,14 +31,4 @@
         {{ h.build_nav_icon(dashboard_groups_route, _('My {Groups}'.format(Groups=group_alias_pural))) }}
       </ul>
     </header>
-    <script>
-      var userplatformuuid = "{{ h.opendata_theme_platform_uuid() }}";
-      var writeKey = "{{ h.opendata_theme_segment_writekey() }}";
-      if(writeKey !== ""){
-        !function(){var i="analytics",analytics=window[i]=window[i]||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","screen","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware","register"];analytics.factory=function(e){return function(){if(window[i].initialized)return window[i][e].apply(window[i],arguments);var n=Array.prototype.slice.call(arguments);if(["track","screen","alias","group","page","identify"].indexOf(e)>-1){var c=document.querySelector("link[rel='canonical']");n.push({__t:"bpc",c:c&&c.getAttribute("href")||void 0,p:location.pathname,u:location.href,s:location.search,t:document.title,r:document.referrer})}n.unshift(e);analytics.push(n);return analytics}};for(var n=0;n<analytics.methods.length;n++){var key=analytics.methods[n];analytics[key]=analytics.factory(key)}analytics.load=function(key,n){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.setAttribute("data-global-segment-analytics-key",i);t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var r=document.getElementsByTagName("script")[0];r.parentNode.insertBefore(t,r);analytics._loadOptions=n};analytics._writeKey=writeKey;;analytics.SNIPPET_VERSION="5.2.0";
-          analytics.load(writeKey);
-          analytics.identify(userplatformuuid || '{{user.id}}', {name: '{{user.fullname}}', email: '{{user.email}}'});
-        }}();
-      }
-    </script>
 {% endblock %}


### PR DESCRIPTION
We need to add the Segment analytics.group() call with the entity id or all the tracking is mixed in a giant soup at the Pendo side.

I also moved the identify() call from the dashboard page to the base page, because it was causing the segment snippet to be executed twice. 