### PR TITLE
Return ckan user uuid if no token found

### DIFF
--- a/ckanext/opendata_theme/base/helpers.py
+++ b/ckanext/opendata_theme/base/helpers.py
@@ -104,16 +104,16 @@ def new_datasets(num=3):
 def get_user_uuid():
     """Return the user platform_uuid for a given email, if there is a token for that email"""
     from ckanext.opengov.auth.db import UserToken
-    if c.user:
+    if c.userobj:
         user = c.userobj
         try:
             user_token = model.Session.query(UserToken).filter_by(user_name=user.email).first()
             if user_token:
                 return user_token.platform_uuid
-            return None
         except Exception as e:
             logger.debug("[opendata_theme] Error querying user token: {}".format(e))
             return None
+        return c.userobj.id
     return None
 
 


### PR DESCRIPTION
# Description
Some users don't have a token so we should return the ckan user uuid as a default if they're logged in.