### PR TITLE
override default template to remove the 'you can change it later' mes…

### DIFF
--- a/ckanext/opendata_theme/opengov_custom_theme/templates/emails/invite_user.txt
+++ b/ckanext/opendata_theme/opengov_custom_theme/templates/emails/invite_user.txt
@@ -1,0 +1,19 @@
+{% trans %}
+Dear {{ user_name }},
+
+You have been invited to {{ site_title }}.
+
+A user has already been created for you with the username {{ user_name }}.
+
+You have been added to the {{ group_type }} {{ group_title }} with the following role: {{ role_name }}.
+
+To accept this invite, please reset your password at:
+
+   {{ reset_link }}
+
+
+Have a nice day.
+
+--
+Message sent by {{ site_title }} ({{ site_url }})
+{% endtrans %}


### PR DESCRIPTION
…sage related to username

Original template file: 
https://github.com/OpenGov-OpenData/ckan/blob/master/ckan/templates/emails/invite_user.txt