### PR TITLE
Add custom script snippet to footer

### DIFF
--- a/ckanext/opendata_theme/base/helpers.py
+++ b/ckanext/opendata_theme/base/helpers.py
@@ -126,7 +126,10 @@ def package_tracking_summary(package):
             tracking_summary = result.get('tracking_summary')
     except Exception:
         logger.debug("[opendata_theme] Error getting dataset tracking_summary")
-        return {}
+        return {
+            'total': 0,
+            'recent': 0
+        }
     return tracking_summary
 
 

--- a/ckanext/opendata_theme/opengov_custom_footer/plugin/__init__.py
+++ b/ckanext/opendata_theme/opengov_custom_footer/plugin/__init__.py
@@ -1,5 +1,6 @@
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
+import re
 
 import ckanext.opendata_theme.base.helpers as helper
 from ckanext.opendata_theme.opengov_custom_footer.controller import CustomFooterController
@@ -48,6 +49,7 @@ class OpenDataThemeFooterPlugin(MixinPlugin):
     def get_helpers(self):
         return {
             'opendata_theme_get_footer_data': get_footer_data,
+            'opendata_theme_get_footer_script_snippet': get_footer_script_snippet,
             'version': helper.version_builder,
         }
 
@@ -57,6 +59,17 @@ def get_footer_data(section):
     if data_dict.get(section):
         return literal(data_dict.get(section))
     return ''
+
+
+def get_footer_script_snippet():
+    pattern = r'<script\b[^>]*>(.*?)<\/script>'
+    script_snippet = toolkit.config.get('ckanext.opendata_theme.script_snippet', '')
+    if not script_snippet:
+        return False
+    match = re.match(pattern, script_snippet, re.IGNORECASE)
+    if not bool(match):
+        return False
+    return literal(script_snippet)
 
 
 def custom_footer_validator(value):

--- a/ckanext/opendata_theme/opengov_custom_footer/plugin/__init__.py
+++ b/ckanext/opendata_theme/opengov_custom_footer/plugin/__init__.py
@@ -77,7 +77,7 @@ def custom_footer_validator(value):
     if layout_type not in ['default', 'custom']:
         raise toolkit.Invalid('Invalid footer layout')
 
-    # content is sanitized by controller soo only taught validation required
+    # content is sanitized by controller so only simple validation required
     content_0 = value.get('content_0')
     if helper.check_characters(content_0):
         raise toolkit.Invalid('Invalid characters in Column 1')

--- a/ckanext/opendata_theme/opengov_custom_footer/templates/custom_footer.html
+++ b/ckanext/opendata_theme/opengov_custom_footer/templates/custom_footer.html
@@ -24,4 +24,8 @@
       {% endblock %}
     </div>
   </div>
+  {% set script_snippet = h.opendata_theme_get_footer_script_snippet() %}
+  {% if script_snippet %}
+    {{ script_snippet }}
+  {% endif %}
 {% endblock %}

--- a/ckanext/opendata_theme/opengov_custom_footer/templates/default_footer.html
+++ b/ckanext/opendata_theme/opengov_custom_footer/templates/default_footer.html
@@ -33,4 +33,8 @@
     {% endblock %}
   </div>
 </div>
+{% set script_snippet = h.opendata_theme_get_footer_script_snippet() %}
+{% if script_snippet %}
+  {{ script_snippet }}
+{% endif %}
 {% endblock %}

--- a/ckanext/opendata_theme/tests/base/test_helpers.py
+++ b/ckanext/opendata_theme/tests/base/test_helpers.py
@@ -1,20 +1,56 @@
 import pytest
 
-from ckanext.opendata_theme.base.helpers import version_builder
+from ckanext.opendata_theme.base.helpers import (
+    abbreviate_name, is_data_dict_active,
+    get_group_alias, get_organization_alias,
+    version_builder, check_characters,
+    sanityze_all_html
+)
 from packaging.version import InvalidVersion
+
+
+def test_abbreviate_name():
+    assert abbreviate_name('John Smith') == 'JS'
+    assert abbreviate_name('test') == 'T'
+
+
+def test_is_data_dict_active():
+    assert is_data_dict_active([{'info': {'label': 'test'}}])
+    assert is_data_dict_active([{'info': {'notes': 'test'}}])
+    assert is_data_dict_active([{'info': {'label': 'test', 'notes': 'test'}}])
+    assert not is_data_dict_active([{'info': {}}])
+    assert not is_data_dict_active([{}])
+    assert not is_data_dict_active([])
+
+
+def test_get_group_alias():
+    assert get_group_alias() == 'Group'
+
+
+def test_get_organization_alias():
+    assert get_organization_alias() == 'Organization'
 
 
 def test_version_builder_positive():
     assert version_builder('2.7') < version_builder('2.9')
     assert version_builder('2.7.0') < version_builder('2.7.3')
     assert version_builder('2.7.3') < version_builder('2.7.12')
-    assert version_builder('2.7.3') < version_builder('2.9.0')
-    assert version_builder('2.7.3') < version_builder('2.9.7')
-    assert version_builder('2.7.12') < version_builder('2.9.0')
-    assert version_builder('2.7.12') < version_builder('2.9.7')
-    assert version_builder('2.7.12') < version_builder('2.10.0')
+    assert version_builder('2.7.3') < version_builder('2.9.11')
+    assert version_builder('2.7.12') < version_builder('2.9.11')
+    assert version_builder('2.9.11') < version_builder('2.10.0')
+    assert version_builder('2.9.11') < version_builder('2.11.0')
 
 
 def test_version_builder_failed_to_build():
     with pytest.raises(InvalidVersion):
         assert version_builder('1.3.xy123')
+
+
+def test_check_characters():
+    assert check_characters('') is False
+
+
+def test_sanityze_all_html():
+    assert sanityze_all_html('<script>alert("test")</script>') == '&lt;script&gt;alert("test")&lt;/script&gt;'
+    assert sanityze_all_html('<a href="test">test</a>') == '&lt;a href="test"&gt;test&lt;/a&gt;'
+    assert sanityze_all_html('test') == 'test'

--- a/ckanext/opendata_theme/tests/opengov_custom_footer/test_custom_footer.py
+++ b/ckanext/opendata_theme/tests/opengov_custom_footer/test_custom_footer.py
@@ -1,5 +1,6 @@
 import pytest
 
+from ckanext.opendata_theme.opengov_custom_footer.plugin import get_footer_script_snippet
 from ckanext.opendata_theme.tests.helpers import do_get, do_post
 
 CUSTOM_FOOTER_URL = "/ckan-admin/custom_footer"
@@ -100,3 +101,7 @@ def test_reset_custom_footer_form_after_some_footer_modification(app):
         'content_2': ''
     }
     check_custom_footer_page_html(reset_response, **expected_data)
+
+
+def test_invalid_get_footer_script_snippet():
+    assert get_footer_script_snippet() is False


### PR DESCRIPTION
# Description
Add config and template helper to add script snippet to footer.
Also fix issue when tracking_summary is not available in a package.