### PR TITLE
Move footer_script_snippet helper function

### DIFF
--- a/ckanext/opendata_theme/base/helpers.py
+++ b/ckanext/opendata_theme/base/helpers.py
@@ -13,6 +13,11 @@ from packaging.version import Version
 from ckanext.opendata_theme.base.compatibility_controller import BaseCompatibilityController
 from ckanext.opendata_theme.opengov_custom_homepage.constants import CUSTOM_NAMING
 
+if toolkit.check_ckan_version(min_version='2.9.0'):
+    from ckan.lib.helpers import literal
+else:
+    from webhelpers.html import literal
+
 
 logger = logging.getLogger(__name__)
 
@@ -300,3 +305,14 @@ def get_default_extent():
             [-66.9513812,24.7433195],[-66.9513812,49.3457868], \
             [-124.7844079,49.3457868],[-124.7844079,24.7433195]]] }'
     )
+
+
+def get_footer_script_snippet():
+    pattern = r'<script\b[^>]*>(.*?)<\/script>'
+    script_snippet = toolkit.config.get('ckanext.opendata_theme.script_snippet', '')
+    if not script_snippet:
+        return False
+    match = re.match(pattern, script_snippet, re.IGNORECASE)
+    if not bool(match):
+        return False
+    return literal(script_snippet)

--- a/ckanext/opendata_theme/opengov_custom_footer/plugin/__init__.py
+++ b/ckanext/opendata_theme/opengov_custom_footer/plugin/__init__.py
@@ -1,6 +1,5 @@
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
-import re
 
 import ckanext.opendata_theme.base.helpers as helper
 from ckanext.opendata_theme.opengov_custom_footer.controller import CustomFooterController
@@ -49,7 +48,6 @@ class OpenDataThemeFooterPlugin(MixinPlugin):
     def get_helpers(self):
         return {
             'opendata_theme_get_footer_data': get_footer_data,
-            'opendata_theme_get_footer_script_snippet': get_footer_script_snippet,
             'version': helper.version_builder,
         }
 
@@ -59,17 +57,6 @@ def get_footer_data(section):
     if data_dict.get(section):
         return literal(data_dict.get(section))
     return ''
-
-
-def get_footer_script_snippet():
-    pattern = r'<script\b[^>]*>(.*?)<\/script>'
-    script_snippet = toolkit.config.get('ckanext.opendata_theme.script_snippet', '')
-    if not script_snippet:
-        return False
-    match = re.match(pattern, script_snippet, re.IGNORECASE)
-    if not bool(match):
-        return False
-    return literal(script_snippet)
 
 
 def custom_footer_validator(value):

--- a/ckanext/opendata_theme/opengov_custom_theme/plugin.py
+++ b/ckanext/opendata_theme/opengov_custom_theme/plugin.py
@@ -33,6 +33,7 @@ class OpenDataThemePlugin(plugins.SingletonPlugin):
             'opendata_theme_group_alias': helper.get_group_alias,
             'opendata_theme_organization_alias': helper.get_organization_alias,
             'opendata_theme_get_default_extent': helper.get_default_extent,
+            'opendata_theme_get_footer_script_snippet': helper.get_footer_script_snippet,
             'opendata_theme_is_data_dict_active': helper.is_data_dict_active,
             'version': helper.version_builder,
             'opendata_theme_segment_writekey': helper.get_segment_writekey,

--- a/ckanext/opendata_theme/tests/base/test_helpers.py
+++ b/ckanext/opendata_theme/tests/base/test_helpers.py
@@ -4,7 +4,8 @@ from ckanext.opendata_theme.base.helpers import (
     abbreviate_name, is_data_dict_active,
     get_group_alias, get_organization_alias,
     version_builder, check_characters,
-    sanityze_all_html
+    sanityze_all_html,
+    get_footer_script_snippet
 )
 from packaging.version import InvalidVersion
 
@@ -54,3 +55,7 @@ def test_sanityze_all_html():
     assert sanityze_all_html('<script>alert("test")</script>') == '&lt;script&gt;alert("test")&lt;/script&gt;'
     assert sanityze_all_html('<a href="test">test</a>') == '&lt;a href="test"&gt;test&lt;/a&gt;'
     assert sanityze_all_html('test') == 'test'
+
+
+def test_invalid_get_footer_script_snippet():
+    assert get_footer_script_snippet() is False

--- a/ckanext/opendata_theme/tests/opengov_custom_footer/test_custom_footer.py
+++ b/ckanext/opendata_theme/tests/opengov_custom_footer/test_custom_footer.py
@@ -1,6 +1,5 @@
 import pytest
 
-from ckanext.opendata_theme.opengov_custom_footer.plugin import get_footer_script_snippet
 from ckanext.opendata_theme.tests.helpers import do_get, do_post
 
 CUSTOM_FOOTER_URL = "/ckan-admin/custom_footer"
@@ -101,7 +100,3 @@ def test_reset_custom_footer_form_after_some_footer_modification(app):
         'content_2': ''
     }
     check_custom_footer_page_html(reset_response, **expected_data)
-
-
-def test_invalid_get_footer_script_snippet():
-    assert get_footer_script_snippet() is False


### PR DESCRIPTION
# Description
Move footer_script_snippet helper function to the opengov_custom_theme plugin from the opengov_custom_footer plugin. The footer_script_snippet helper function is called in a template in opengov_custom_theme, not opengov_custom_footer.