### PR TITLE
feat: add custom explanation text for homepage sections

### DIFF
--- a/ckanext/opendata_theme/base/helpers.py
+++ b/ckanext/opendata_theme/base/helpers.py
@@ -167,28 +167,25 @@ def get_organization_alias():
     return str(config.get('ckan.organization_alias', 'Organization'))
 
 
-def get_custom_name(key, default_name):
+def _get_custom_value(key, default_value=''):
+    """Internal helper to retrieve custom values from CUSTOM_NAMING config."""
     custom_naming = toolkit.get_action('config_option_show')({'ignore_auth': True}, {"key": CUSTOM_NAMING})
     if not custom_naming:
-        return default_name
+        return default_value
     custom_naming = ast.literal_eval(custom_naming)
-    name = custom_naming.get(key)
-    if not name:
-        return default_name
+    item = custom_naming.get(key)
+    if not item:
+        return default_value
     else:
-        return toolkit.h.markdown_extract(name.get('value', default_name))
+        return toolkit.h.markdown_extract(item.get('value', default_value))
+
+
+def get_custom_name(key, default_name):
+    return _get_custom_value(key, default_name)
 
 
 def get_custom_explanation(key, default_explanation=''):
-    custom_naming = toolkit.get_action('config_option_show')({'ignore_auth': True}, {"key": CUSTOM_NAMING})
-    if not custom_naming:
-        return default_explanation
-    custom_naming = ast.literal_eval(custom_naming)
-    explanation = custom_naming.get(key)
-    if not explanation:
-        return default_explanation
-    else:
-        return toolkit.h.markdown_extract(explanation.get('value', default_explanation))
+    return _get_custom_value(key, default_explanation)
 
 
 def get_data(key):

--- a/ckanext/opendata_theme/base/helpers.py
+++ b/ckanext/opendata_theme/base/helpers.py
@@ -179,6 +179,18 @@ def get_custom_name(key, default_name):
         return toolkit.h.markdown_extract(name.get('value', default_name))
 
 
+def get_custom_explanation(key, default_explanation=''):
+    custom_naming = toolkit.get_action('config_option_show')({'ignore_auth': True}, {"key": CUSTOM_NAMING})
+    if not custom_naming:
+        return default_explanation
+    custom_naming = ast.literal_eval(custom_naming)
+    explanation = custom_naming.get(key)
+    if not explanation:
+        return default_explanation
+    else:
+        return toolkit.h.markdown_extract(explanation.get('value', default_explanation))
+
+
 def get_data(key):
     return BaseCompatibilityController.get_data(key)
 

--- a/ckanext/opendata_theme/extended_themes/bostonma/templates/home/snippets/groups.html
+++ b/ckanext/opendata_theme/extended_themes/bostonma/templates/home/snippets/groups.html
@@ -8,7 +8,10 @@
                             {{ h.opendata_theme_get_custom_name('groups-custom-name', 'Groups') }}
                         </a>
                     </h2>
-                    <span class="heading-explanation">As datasets are published, they are tagged with categories so you can learn about popular topics. Explore them below.</span>
+                    {% set groups_explanation = h.opendata_theme_get_custom_explanation('groups-custom-explanation', 'As datasets are published, they are grouped into categories so you can learn about popular topics. Explore them below.') %}
+                    {% if groups_explanation %}
+                        <span class="heading-explanation">{{ groups_explanation }}</span>
+                    {% endif %}
                     {% for group in h.opendata_theme_get_groups() %}
                         {% if group.package_count > 0 %}
                             <a href="/group/{{ group.name }}"

--- a/ckanext/opendata_theme/extended_themes/bostonma/templates/home/snippets/opendata_theme_showcase.html
+++ b/ckanext/opendata_theme/extended_themes/bostonma/templates/home/snippets/opendata_theme_showcase.html
@@ -8,7 +8,10 @@
                             {{ h.opendata_theme_get_custom_name('showcases-custom-name', 'Showcases') }}
                         </a>
                     </h2>
-                    <span class="heading-explanation">See what our users are doing with open data.</span>
+                    {% set showcases_explanation = h.opendata_theme_get_custom_explanation('showcases-custom-explanation', 'See what our users are doing with open data.') %}
+                    {% if showcases_explanation %}
+                        <span class="heading-explanation">{{ showcases_explanation }}</span>
+                    {% endif %}
                     {% snippet 'home/snippets/showcase_list.html', showcases=h.opendata_theme_get_showcases() %}
                 </div>
             </div>

--- a/ckanext/opendata_theme/extended_themes/cnra/templates/home/snippets/groups.html
+++ b/ckanext/opendata_theme/extended_themes/cnra/templates/home/snippets/groups.html
@@ -8,7 +8,10 @@
                             {{ h.opendata_theme_get_custom_name('groups-custom-name', 'Groups') }}
                         </a>
                     </h2>
-                    <span class="heading-explanation">As datasets are published, they are tagged with categories so you can learn about popular topics.</span>
+                    {% set groups_explanation = h.opendata_theme_get_custom_explanation('groups-custom-explanation', '') %}
+                    {% if groups_explanation %}
+                        <span class="heading-explanation">{{ groups_explanation }}</span>
+                    {% endif %}
                     {% for group in h.opendata_theme_get_groups() %}
                         {% if group.package_count > 0 %}
                             <a href="/group/{{ group.name }}"

--- a/ckanext/opendata_theme/extended_themes/cnra/templates/home/snippets/opendata_theme_showcase.html
+++ b/ckanext/opendata_theme/extended_themes/cnra/templates/home/snippets/opendata_theme_showcase.html
@@ -8,7 +8,10 @@
                             {{ h.opendata_theme_get_custom_name('showcases-custom-name', 'Showcases') }}
                         </a>
                     </h2>
-                    <span class="heading-explanation">See what our users are doing with open data.</span>
+                    {% set showcases_explanation = h.opendata_theme_get_custom_explanation('showcases-custom-explanation', 'See what our users are doing with open data.') %}
+                    {% if showcases_explanation %}
+                        <span class="heading-explanation">{{ showcases_explanation }}</span>
+                    {% endif %}
                     {% snippet 'home/snippets/showcase_list.html', showcases=h.opendata_theme_get_showcases() %}
                 </div>
             </div>

--- a/ckanext/opendata_theme/extended_themes/milwaukee/templates/home/snippets/groups.html
+++ b/ckanext/opendata_theme/extended_themes/milwaukee/templates/home/snippets/groups.html
@@ -8,7 +8,10 @@
                             {{ h.opendata_theme_get_custom_name('groups-custom-name', 'Groups') }}
                         </a>
                     </h2>
-                    <span class="heading-explanation">These datasets are organized according to city services-related topics.</span>
+                    {% set groups_explanation = h.opendata_theme_get_custom_explanation('groups-custom-explanation', 'These datasets are organized according to city services-related topics.') %}
+                    {% if groups_explanation %}
+                        <span class="heading-explanation">{{ groups_explanation }}</span>
+                    {% endif %}
                     {% for group in h.opendata_theme_get_groups() %}
                         {% if group.package_count > 0 %}
                             <a href="/group/{{ group.name }}"

--- a/ckanext/opendata_theme/extended_themes/milwaukee/templates/home/snippets/opendata_theme_showcase.html
+++ b/ckanext/opendata_theme/extended_themes/milwaukee/templates/home/snippets/opendata_theme_showcase.html
@@ -8,7 +8,10 @@
                             {{ h.opendata_theme_get_custom_name('showcases-custom-name', 'Showcases') }}
                         </a>
                     </h2>
-                    <span class="heading-explanation">These datasets represent the most popular and important information requested by the public.</span>
+                    {% set showcases_explanation = h.opendata_theme_get_custom_explanation('showcases-custom-explanation', 'These datasets represent the most popular and important information requested by the public.') %}
+                    {% if showcases_explanation %}
+                        <span class="heading-explanation">{{ showcases_explanation }}</span>
+                    {% endif %}
                     {% snippet 'home/snippets/showcase_list.html', showcases=h.opendata_theme_get_showcases() %}
                 </div>
             </div>

--- a/ckanext/opendata_theme/extended_themes/phoenixaz/templates/home/snippets/groups.html
+++ b/ckanext/opendata_theme/extended_themes/phoenixaz/templates/home/snippets/groups.html
@@ -8,7 +8,10 @@
                             {{ h.opendata_theme_get_custom_name('groups-custom-name', 'Groups') }}
                         </a>
                     </h2>
-                    <span class="heading-explanation">These datasets are organized according to city services-related topics.</span>
+                    {% set groups_explanation = h.opendata_theme_get_custom_explanation('groups-custom-explanation', 'These datasets are organized according to city services-related topics.') %}
+                    {% if groups_explanation %}
+                        <span class="heading-explanation">{{ groups_explanation }}</span>
+                    {% endif %}
                     {% for group in h.opendata_theme_get_groups() %}
                         {% if group.package_count > 0 %}
                             <a href="/group/{{ group.name }}"

--- a/ckanext/opendata_theme/extended_themes/phoenixaz/templates/home/snippets/opendata_theme_showcase.html
+++ b/ckanext/opendata_theme/extended_themes/phoenixaz/templates/home/snippets/opendata_theme_showcase.html
@@ -8,7 +8,10 @@
                             {{ h.opendata_theme_get_custom_name('showcases-custom-name', 'Showcases') }}
                         </a>
                     </h2>
-                    <span class="heading-explanation">These datasets represent the most popular and important information requested by the public.</span>
+                    {% set showcases_explanation = h.opendata_theme_get_custom_explanation('showcases-custom-explanation', 'These datasets represent the most popular and important information requested by the public.') %}
+                    {% if showcases_explanation %}
+                        <span class="heading-explanation">{{ showcases_explanation }}</span>
+                    {% endif %}
                     {% snippet 'home/snippets/showcase_list.html', showcases=h.opendata_theme_get_showcases() %}
                 </div>
             </div>

--- a/ckanext/opendata_theme/extended_themes/sugarland/templates/home/snippets/groups.html
+++ b/ckanext/opendata_theme/extended_themes/sugarland/templates/home/snippets/groups.html
@@ -8,7 +8,10 @@
                             {{ h.opendata_theme_get_custom_name('groups-custom-name', 'Groups') }}
                         </a>
                     </h2>
-                    <span class="heading-explanation">These datasets are organized based on the City's eight strategic outcomes.</span>
+                    {% set groups_explanation = h.opendata_theme_get_custom_explanation('groups-custom-explanation', 'These datasets are organized based on the City\'s eight strategic outcomes.') %}
+                    {% if groups_explanation %}
+                        <span class="heading-explanation">{{ groups_explanation }}</span>
+                    {% endif %}
                     {% for group in h.opendata_theme_get_groups() %}
                         {% if group.package_count > 0 %}
                             <a href="/group/{{ group.name }}"

--- a/ckanext/opendata_theme/extended_themes/sugarland/templates/home/snippets/opendata_theme_showcase.html
+++ b/ckanext/opendata_theme/extended_themes/sugarland/templates/home/snippets/opendata_theme_showcase.html
@@ -8,7 +8,10 @@
                             {{ h.opendata_theme_get_custom_name('showcases-custom-name', 'Showcases') }}
                         </a>
                     </h2>
-                    <span class="heading-explanation">These showcases highlight publications, projects, or applications related to popular datasets. Showcases are data in action.</span>
+                    {% set showcases_explanation = h.opendata_theme_get_custom_explanation('showcases-custom-explanation', 'These showcases highlight publications, projects, or applications related to popular datasets. Showcases are data in action.') %}
+                    {% if showcases_explanation %}
+                        <span class="heading-explanation">{{ showcases_explanation }}</span>
+                    {% endif %}
                     {% snippet 'home/snippets/showcase_list.html', showcases=h.opendata_theme_get_showcases() %}
                 </div>
             </div>

--- a/ckanext/opendata_theme/opengov_custom_homepage/controller.py
+++ b/ckanext/opendata_theme/opengov_custom_homepage/controller.py
@@ -74,8 +74,10 @@ class CustomHomepageController(BaseCompatibilityController):
     @staticmethod
     def reorder_fields(names):
         field_order = [
-            'groups-custom-name', 'showcases-custom-name',
-            'popular-datasets-custom-name', 'recent-datasets-custom-name'
+            'groups-custom-name', 'groups-custom-explanation',
+            'showcases-custom-name', 'showcases-custom-explanation',
+            'popular-datasets-custom-name', 'popular-datasets-custom-explanation',
+            'recent-datasets-custom-name', 'recent-datasets-custom-explanation'
         ]
         sorted_fields = []
         for field_name in field_order:

--- a/ckanext/opendata_theme/opengov_custom_homepage/plugin/__init__.py
+++ b/ckanext/opendata_theme/opengov_custom_homepage/plugin/__init__.py
@@ -49,6 +49,7 @@ class OpenDataThemeHomepagePlugin(MixinPlugin):
             'opendata_theme_get_datasets_recent': helper.recent_datasets,
             'opendata_theme_get_package_tracking_summary': helper.package_tracking_summary,
             'opendata_theme_get_custom_name': helper.get_custom_name,
+            'opendata_theme_get_custom_explanation': helper.get_custom_explanation,
             'opendata_theme_get_data': helper.get_data,
             'opendata_theme_custom_page_exists': helper.custom_page_exists,
             'version': helper.version_builder,

--- a/ckanext/opendata_theme/opengov_custom_homepage/processor.py
+++ b/ckanext/opendata_theme/opengov_custom_homepage/processor.py
@@ -9,10 +9,22 @@ class GroupsNaming(AbstractParser):
     _default_value = "Groups"
 
 
+class GroupsExplanation(AbstractParser):
+    form_name = "groups-custom-explanation"
+    title = "Groups Section Explanation"
+    _default_value = "As datasets are published, they are grouped into categories so you can learn about popular topics."
+
+
 class ShowcasesNaming(AbstractParser):
     form_name = "showcases-custom-name"
     title = "Showcases Section Title"
     _default_value = "Showcases"
+
+
+class ShowcasesExplanation(AbstractParser):
+    form_name = "showcases-custom-explanation"
+    title = "Showcases Section Explanation"
+    _default_value = ""
 
 
 class PopularDatasetsNaming(AbstractParser):
@@ -21,25 +33,45 @@ class PopularDatasetsNaming(AbstractParser):
     _default_value = "Popular Datasets"
 
 
+class PopularDatasetsExplanation(AbstractParser):
+    form_name = "popular-datasets-custom-explanation"
+    title = "Popular Datasets Section Explanation"
+    _default_value = "Browse popular datasets below and see what other citizens find interesting."
+
+
 class RecentDatasetsNaming(AbstractParser):
     form_name = "recent-datasets-custom-name"
     title = "Recent Datasets Section Title"
     _default_value = "New and Recent Datasets"
 
 
+class RecentDatasetsExplanation(AbstractParser):
+    form_name = "recent-datasets-custom-explanation"
+    title = "Recent Datasets Section Explanation"
+    _default_value = "Browse new or modified datasets below. Click to view details or explore content."
+
+
 class CustomNamingProcessor:
 
     def __init__(self):
         self.groups = GroupsNaming()
+        self.groups_explanation = GroupsExplanation()
         self.showcases = ShowcasesNaming()
+        self.showcases_explanation = ShowcasesExplanation()
         self.popular_datasets = PopularDatasetsNaming()
+        self.popular_datasets_explanation = PopularDatasetsExplanation()
         self.recent_datasets = RecentDatasetsNaming()
+        self.recent_datasets_explanation = RecentDatasetsExplanation()
 
         self.naming_processors = (
             self.groups,
+            self.groups_explanation,
             self.showcases,
+            self.showcases_explanation,
             self.popular_datasets,
-            self.recent_datasets
+            self.popular_datasets_explanation,
+            self.recent_datasets,
+            self.recent_datasets_explanation
         )
 
     def get_custom_naming(self, data):

--- a/ckanext/opendata_theme/opengov_custom_homepage/templates/admin/custom_homepage_form.html
+++ b/ckanext/opendata_theme/opengov_custom_homepage/templates/admin/custom_homepage_form.html
@@ -71,6 +71,7 @@
                 <p><i>Layout 3:</i> Introductory Area and Showcase Tiles.</p>
                 <hr>
                 <p><strong>Section Titles:</strong> Modify the title of a section on the homepage.</p>
+                <p><strong>Section Explanations:</strong> Add explanatory text below section titles to provide context to users.</p>
             {% endblock %}
         </div>
     </div>

--- a/ckanext/opendata_theme/opengov_custom_homepage/templates/home/snippets/groups.html
+++ b/ckanext/opendata_theme/opengov_custom_homepage/templates/home/snippets/groups.html
@@ -8,6 +8,10 @@
               {{ h.opendata_theme_get_custom_name('groups-custom-name', 'Groups') }}
             </a>
           </h2>
+          {% set groups_explanation = h.opendata_theme_get_custom_explanation('groups-custom-explanation', '') %}
+          {% if groups_explanation %}
+            <span class="heading-explanation">{{ groups_explanation }}</span>
+          {% endif %}
           <div class="flex-wrap-container">
             {% for group in h.opendata_theme_get_groups() %}
               <a href="/group/{{ group.name }}"

--- a/ckanext/opendata_theme/opengov_custom_homepage/templates/home/snippets/opendata_theme_showcase.html
+++ b/ckanext/opendata_theme/opengov_custom_homepage/templates/home/snippets/opendata_theme_showcase.html
@@ -8,6 +8,10 @@
                             {{ h.opendata_theme_get_custom_name('showcases-custom-name', 'Showcases') }}
                         </a>
                     </h2>
+                    {% set showcases_explanation = h.opendata_theme_get_custom_explanation('showcases-custom-explanation', '') %}
+                    {% if showcases_explanation %}
+                        <span class="heading-explanation">{{ showcases_explanation }}</span>
+                    {% endif %}
                     {% snippet 'home/snippets/showcase_list.html', showcases=h.opendata_theme_get_showcases() %}
                 </div>
             </div>

--- a/ckanext/opendata_theme/opengov_custom_homepage/templates/home/snippets/popular_datasets.html
+++ b/ckanext/opendata_theme/opengov_custom_homepage/templates/home/snippets/popular_datasets.html
@@ -2,7 +2,10 @@
 
 <div class="module-content">
   <h2 class="heading"><a href="/dataset?sort=views_recent+desc">{{ h.opendata_theme_get_custom_name('popular-datasets-custom-name', 'Popular Datasets') }}</a></h2>
-  <span class="heading-explanation">Browse popular datasets below and see what other citizens find interesting.</span>
+  {% set popular_explanation = h.opendata_theme_get_custom_explanation('popular-datasets-custom-explanation', 'Browse popular datasets below and see what other citizens find interesting.') %}
+  {% if popular_explanation %}
+    <span class="heading-explanation">{{ popular_explanation }}</span>
+  {% endif %}
   <section>
     {% snippet 'home/snippets/package_list.html', packages=popular_datasets, note_type='recent_views' %}
   </section>

--- a/ckanext/opendata_theme/opengov_custom_homepage/templates/home/snippets/recent_datasets.html
+++ b/ckanext/opendata_theme/opengov_custom_homepage/templates/home/snippets/recent_datasets.html
@@ -2,7 +2,10 @@
 
 <div class="module-content">
   <h2 class="heading"><a href="/dataset">{{ h.opendata_theme_get_custom_name('recent-datasets-custom-name', 'New and Recent Datasets') }}</a></h2>
-  <span class="heading-explanation">Browse new or modified datasets below. Click to view details or explore content.</span>
+  {% set recent_explanation = h.opendata_theme_get_custom_explanation('recent-datasets-custom-explanation', 'Browse new or modified datasets below. Click to view details or explore content.') %}
+  {% if recent_explanation %}
+    <span class="heading-explanation">{{ recent_explanation }}</span>
+  {% endif %}
   <section id="recent-list">
     {% snippet 'home/snippets/package_list.html', packages=latest_datasets, note_type='updated' %}
   </section>

--- a/ckanext/opendata_theme/tests/base/test_helpers.py
+++ b/ckanext/opendata_theme/tests/base/test_helpers.py
@@ -1,11 +1,14 @@
 import pytest
+from unittest import mock
 
 from ckanext.opendata_theme.base.helpers import (
     abbreviate_name, is_data_dict_active,
     get_group_alias, get_organization_alias,
     version_builder, check_characters,
     sanityze_all_html,
-    get_footer_script_snippet
+    get_footer_script_snippet,
+    get_custom_name,
+    get_custom_explanation
 )
 from packaging.version import InvalidVersion
 
@@ -59,3 +62,92 @@ def test_sanityze_all_html():
 
 def test_invalid_get_footer_script_snippet():
     assert get_footer_script_snippet() is False
+
+
+@mock.patch('ckanext.opendata_theme.base.helpers.toolkit.get_action')
+def test_get_custom_name_with_no_config(mock_get_action):
+    """Test get_custom_name returns default when no config exists"""
+    mock_get_action.return_value.return_value = None
+    result = get_custom_name('groups-custom-name', 'Default Groups')
+    assert result == 'Default Groups'
+
+
+@mock.patch('ckanext.opendata_theme.base.helpers.toolkit.get_action')
+def test_get_custom_name_with_missing_key(mock_get_action):
+    """Test get_custom_name returns default when key is missing"""
+    mock_get_action.return_value.return_value = str({
+        'other-key': {'title': 'Other', 'value': 'Other Value'}
+    })
+    result = get_custom_name('groups-custom-name', 'Default Groups')
+    assert result == 'Default Groups'
+
+
+@mock.patch('ckanext.opendata_theme.base.helpers.toolkit.h.markdown_extract')
+@mock.patch('ckanext.opendata_theme.base.helpers.toolkit.get_action')
+def test_get_custom_name_with_valid_config(mock_get_action, mock_markdown_extract):
+    """Test get_custom_name returns custom value when config exists"""
+    mock_get_action.return_value.return_value = str({
+        'groups-custom-name': {'title': 'Groups Title', 'value': 'Custom Groups'}
+    })
+    mock_markdown_extract.return_value = 'Custom Groups'
+    result = get_custom_name('groups-custom-name', 'Default Groups')
+    assert result == 'Custom Groups'
+    mock_markdown_extract.assert_called_once_with('Custom Groups')
+
+
+@mock.patch('ckanext.opendata_theme.base.helpers.toolkit.get_action')
+def test_get_custom_explanation_with_no_config(mock_get_action):
+    """Test get_custom_explanation returns default when no config exists"""
+    mock_get_action.return_value.return_value = None
+    result = get_custom_explanation('groups-custom-explanation', 'Default explanation text')
+    assert result == 'Default explanation text'
+
+
+@mock.patch('ckanext.opendata_theme.base.helpers.toolkit.get_action')
+def test_get_custom_explanation_with_empty_default(mock_get_action):
+    """Test get_custom_explanation returns empty string when no config and no default"""
+    mock_get_action.return_value.return_value = None
+    result = get_custom_explanation('showcases-custom-explanation')
+    assert result == ''
+
+
+@mock.patch('ckanext.opendata_theme.base.helpers.toolkit.get_action')
+def test_get_custom_explanation_with_missing_key(mock_get_action):
+    """Test get_custom_explanation returns default when key is missing"""
+    mock_get_action.return_value.return_value = str({
+        'other-key': {'title': 'Other', 'value': 'Other Value'}
+    })
+    result = get_custom_explanation('groups-custom-explanation', 'Default explanation')
+    assert result == 'Default explanation'
+
+
+@mock.patch('ckanext.opendata_theme.base.helpers.toolkit.h.markdown_extract')
+@mock.patch('ckanext.opendata_theme.base.helpers.toolkit.get_action')
+def test_get_custom_explanation_with_valid_config(mock_get_action, mock_markdown_extract):
+    """Test get_custom_explanation returns custom value when config exists"""
+    mock_get_action.return_value.return_value = str({
+        'groups-custom-explanation': {
+            'title': 'Groups Explanation',
+            'value': 'This is a custom explanation text'
+        }
+    })
+    mock_markdown_extract.return_value = 'This is a custom explanation text'
+    result = get_custom_explanation('groups-custom-explanation', 'Default explanation')
+    assert result == 'This is a custom explanation text'
+    mock_markdown_extract.assert_called_once_with('This is a custom explanation text')
+
+
+@mock.patch('ckanext.opendata_theme.base.helpers.toolkit.h.markdown_extract')
+@mock.patch('ckanext.opendata_theme.base.helpers.toolkit.get_action')
+def test_get_custom_explanation_with_markdown(mock_get_action, mock_markdown_extract):
+    """Test get_custom_explanation processes markdown correctly"""
+    mock_get_action.return_value.return_value = str({
+        'popular-datasets-custom-explanation': {
+            'title': 'Popular Datasets Explanation',
+            'value': '**Browse** popular datasets'
+        }
+    })
+    mock_markdown_extract.return_value = 'Browse popular datasets'
+    result = get_custom_explanation('popular-datasets-custom-explanation', '')
+    assert result == 'Browse popular datasets'
+    mock_markdown_extract.assert_called_once_with('**Browse** popular datasets')

--- a/ckanext/opendata_theme/tests/opengov_custom_homepage/test_custom_homepage.py
+++ b/ckanext/opendata_theme/tests/opengov_custom_homepage/test_custom_homepage.py
@@ -8,9 +8,13 @@ RESET_CUSTOM_HOMEPAGE_URL = "/ckan-admin/reset_custom_homepage"
 DEFAULT_DATA = {
     'custom_homepage_layout': '1',
     'popular-datasets-custom-name': 'Popular Datasets',
+    'popular-datasets-custom-explanation': 'Browse popular datasets below and see what other citizens find interesting.',
     'recent-datasets-custom-name': 'New and Recent Datasets',
+    'recent-datasets-custom-explanation': 'Browse new or modified datasets below. Click to view details or explore content.',
     'groups-custom-name': 'Groups',
-    'showcases-custom-name': 'Showcases'
+    'groups-custom-explanation': 'As datasets are published, they are grouped into categories so you can learn about popular topics.',
+    'showcases-custom-name': 'Showcases',
+    'showcases-custom-explanation': ''
 }
 
 DEFAULT_HEADERS = (
@@ -67,9 +71,13 @@ def test_post_custom_homepage_with_changes(app):
     data = {
         'custom_homepage_layout': '2',
         'popular-datasets-custom-name': 'Test 1',
+        'popular-datasets-custom-explanation': 'Test explanation 1',
         'recent-datasets-custom-name': 'Test 2',
+        'recent-datasets-custom-explanation': 'Test explanation 2',
         'groups-custom-name': 'Test 3',
-        'showcases-custom-name': 'Test 4'
+        'groups-custom-explanation': 'Test explanation 3',
+        'showcases-custom-name': 'Test 4',
+        'showcases-custom-explanation': 'Test explanation 4'
     }
     response = do_post(app, CUSTOM_HOMEPAGE_URL, is_sysadmin=True, data=data)
 
@@ -101,3 +109,61 @@ def test_reset_custom_homepage_changes(app):
 
     homepage_response = do_get(app, '/', is_sysadmin=False)
     check_homepage_html(homepage_response, expected_data=DEFAULT_HEADERS)
+
+
+@pytest.mark.usefixtures("clean_db", "with_request_context")
+def test_post_custom_homepage_with_explanation_only(app):
+    """Test that explanation text can be set independently of titles"""
+    data = {
+        'custom_homepage_layout': '1',
+        'popular-datasets-custom-name': 'Popular Datasets',
+        'popular-datasets-custom-explanation': 'Custom explanation for popular datasets',
+        'recent-datasets-custom-name': 'New and Recent Datasets',
+        'recent-datasets-custom-explanation': 'Custom explanation for recent datasets',
+        'groups-custom-name': 'Groups',
+        'groups-custom-explanation': 'Custom explanation for groups',
+        'showcases-custom-name': 'Showcases',
+        'showcases-custom-explanation': 'Custom explanation for showcases'
+    }
+    response = do_post(app, CUSTOM_HOMEPAGE_URL, is_sysadmin=True, data=data)
+
+    check_custom_homepage_html(response, expected_form_data=data.copy())
+
+
+@pytest.mark.usefixtures("clean_db", "with_request_context")
+def test_post_custom_homepage_with_empty_explanation(app):
+    """Test that empty explanation text is handled correctly"""
+    data = {
+        'custom_homepage_layout': '1',
+        'popular-datasets-custom-name': 'Popular Datasets',
+        'popular-datasets-custom-explanation': '',
+        'recent-datasets-custom-name': 'New and Recent Datasets',
+        'recent-datasets-custom-explanation': '',
+        'groups-custom-name': 'Groups',
+        'groups-custom-explanation': '',
+        'showcases-custom-name': 'Showcases',
+        'showcases-custom-explanation': ''
+    }
+    response = do_post(app, CUSTOM_HOMEPAGE_URL, is_sysadmin=True, data=data)
+
+    check_custom_homepage_html(response, expected_form_data=data.copy())
+
+
+@pytest.mark.usefixtures("clean_db", "with_request_context")
+def test_post_custom_homepage_with_markdown_explanation(app):
+    """Test that markdown in explanation text is processed"""
+    data = {
+        'custom_homepage_layout': '1',
+        'popular-datasets-custom-name': 'Popular Datasets',
+        'popular-datasets-custom-explanation': '**Browse** popular datasets',
+        'recent-datasets-custom-name': 'New and Recent Datasets',
+        'recent-datasets-custom-explanation': 'Browse *new* datasets',
+        'groups-custom-name': 'Groups',
+        'groups-custom-explanation': 'Learn about [groups](http://example.com)',
+        'showcases-custom-name': 'Showcases',
+        'showcases-custom-explanation': ''
+    }
+    response = do_post(app, CUSTOM_HOMEPAGE_URL, is_sysadmin=True, data=data)
+
+    # Note: The markdown will be stored as-is and processed when rendered
+    assert response.status_code == 200

--- a/ckanext/opendata_theme/tests/opengov_custom_homepage/test_custom_homepage.py
+++ b/ckanext/opendata_theme/tests/opengov_custom_homepage/test_custom_homepage.py
@@ -12,7 +12,10 @@ DEFAULT_DATA = {
     'recent-datasets-custom-name': 'New and Recent Datasets',
     'recent-datasets-custom-explanation': 'Browse new or modified datasets below. Click to view details or explore content.',
     'groups-custom-name': 'Groups',
-    'groups-custom-explanation': 'As datasets are published, they are grouped into categories so you can learn about popular topics.',
+    'groups-custom-explanation': (
+        'As datasets are published, they are grouped into categories '
+        'so you can learn about popular topics.'
+    ),
     'showcases-custom-name': 'Showcases',
     'showcases-custom-explanation': ''
 }

--- a/ckanext/opendata_theme/tests/opengov_custom_homepage/test_processor.py
+++ b/ckanext/opendata_theme/tests/opengov_custom_homepage/test_processor.py
@@ -1,13 +1,7 @@
-import pytest
-
 from ckanext.opendata_theme.opengov_custom_homepage.processor import (
-    GroupsNaming,
     GroupsExplanation,
-    ShowcasesNaming,
     ShowcasesExplanation,
-    PopularDatasetsNaming,
     PopularDatasetsExplanation,
-    RecentDatasetsNaming,
     RecentDatasetsExplanation,
     CustomNamingProcessor
 )
@@ -18,7 +12,10 @@ class TestGroupsExplanation:
 
     def test_default_value(self):
         processor = GroupsExplanation()
-        assert processor._default_value == "As datasets are published, they are grouped into categories so you can learn about popular topics."
+        assert processor._default_value == (
+            "As datasets are published, they are grouped into categories "
+            "so you can learn about popular topics."
+        )
 
     def test_form_name(self):
         processor = GroupsExplanation()
@@ -38,7 +35,7 @@ class TestGroupsExplanation:
         processor = GroupsExplanation()
         form_data = {'groups-custom-explanation': ''}
         processor.parse_form_data(form_data)
-        assert processor.value == processor._default_value
+        assert processor.value == ''
 
 
 class TestShowcasesExplanation:
@@ -68,7 +65,9 @@ class TestPopularDatasetsExplanation:
 
     def test_default_value(self):
         processor = PopularDatasetsExplanation()
-        assert processor._default_value == "Browse popular datasets below and see what other citizens find interesting."
+        assert processor._default_value == (
+            "Browse popular datasets below and see what other citizens find interesting."
+        )
 
     def test_form_name(self):
         processor = PopularDatasetsExplanation()
@@ -90,7 +89,9 @@ class TestRecentDatasetsExplanation:
 
     def test_default_value(self):
         processor = RecentDatasetsExplanation()
-        assert processor._default_value == "Browse new or modified datasets below. Click to view details or explore content."
+        assert processor._default_value == (
+            "Browse new or modified datasets below. Click to view details or explore content."
+        )
 
     def test_form_name(self):
         processor = RecentDatasetsExplanation()
@@ -173,22 +174,29 @@ class TestCustomNamingProcessor:
         result = processor.get_custom_naming(form_data)
 
         # Check that default values are used
-        assert result['groups-custom-explanation']['value'] == "As datasets are published, they are grouped into categories so you can learn about popular topics."
+        assert result['groups-custom-explanation']['value'] == (
+            "As datasets are published, they are grouped into categories "
+            "so you can learn about popular topics."
+        )
         assert result['showcases-custom-explanation']['value'] == ""
-        assert result['popular-datasets-custom-explanation']['value'] == "Browse popular datasets below and see what other citizens find interesting."
-        assert result['recent-datasets-custom-explanation']['value'] == "Browse new or modified datasets below. Click to view details or explore content."
+        assert result['popular-datasets-custom-explanation']['value'] == (
+            "Browse popular datasets below and see what other citizens find interesting."
+        )
+        assert result['recent-datasets-custom-explanation']['value'] == (
+            "Browse new or modified datasets below. Click to view details or explore content."
+        )
 
     def test_get_custom_naming_with_mixed_values(self):
         processor = CustomNamingProcessor()
         form_data = {
             'groups-custom-name': 'Custom Groups',
-            'groups-custom-explanation': '',  # Empty, should use default
+            'groups-custom-explanation': '',  # Empty, clears the text
             'showcases-custom-name': '',
             'showcases-custom-explanation': 'Custom showcases text',  # Custom value
         }
         result = processor.get_custom_naming(form_data)
 
         assert result['groups-custom-name']['value'] == 'Custom Groups'
-        assert result['groups-custom-explanation']['value'] == "As datasets are published, they are grouped into categories so you can learn about popular topics."
-        assert result['showcases-custom-name']['value'] == 'Showcases'
+        assert result['groups-custom-explanation']['value'] == ''
+        assert result['showcases-custom-name']['value'] == ''
         assert result['showcases-custom-explanation']['value'] == 'Custom showcases text'

--- a/ckanext/opendata_theme/tests/opengov_custom_homepage/test_processor.py
+++ b/ckanext/opendata_theme/tests/opengov_custom_homepage/test_processor.py
@@ -1,0 +1,194 @@
+import pytest
+
+from ckanext.opendata_theme.opengov_custom_homepage.processor import (
+    GroupsNaming,
+    GroupsExplanation,
+    ShowcasesNaming,
+    ShowcasesExplanation,
+    PopularDatasetsNaming,
+    PopularDatasetsExplanation,
+    RecentDatasetsNaming,
+    RecentDatasetsExplanation,
+    CustomNamingProcessor
+)
+
+
+class TestGroupsExplanation:
+    """Test GroupsExplanation processor"""
+
+    def test_default_value(self):
+        processor = GroupsExplanation()
+        assert processor._default_value == "As datasets are published, they are grouped into categories so you can learn about popular topics."
+
+    def test_form_name(self):
+        processor = GroupsExplanation()
+        assert processor.form_name == "groups-custom-explanation"
+
+    def test_title(self):
+        processor = GroupsExplanation()
+        assert processor.title == "Groups Section Explanation"
+
+    def test_parse_form_data_with_custom_value(self):
+        processor = GroupsExplanation()
+        form_data = {'groups-custom-explanation': 'Custom explanation text'}
+        processor.parse_form_data(form_data)
+        assert processor.value == 'Custom explanation text'
+
+    def test_parse_form_data_with_empty_value(self):
+        processor = GroupsExplanation()
+        form_data = {'groups-custom-explanation': ''}
+        processor.parse_form_data(form_data)
+        assert processor.value == processor._default_value
+
+
+class TestShowcasesExplanation:
+    """Test ShowcasesExplanation processor"""
+
+    def test_default_value(self):
+        processor = ShowcasesExplanation()
+        assert processor._default_value == ""
+
+    def test_form_name(self):
+        processor = ShowcasesExplanation()
+        assert processor.form_name == "showcases-custom-explanation"
+
+    def test_title(self):
+        processor = ShowcasesExplanation()
+        assert processor.title == "Showcases Section Explanation"
+
+    def test_parse_form_data_with_custom_value(self):
+        processor = ShowcasesExplanation()
+        form_data = {'showcases-custom-explanation': 'Custom showcase explanation'}
+        processor.parse_form_data(form_data)
+        assert processor.value == 'Custom showcase explanation'
+
+
+class TestPopularDatasetsExplanation:
+    """Test PopularDatasetsExplanation processor"""
+
+    def test_default_value(self):
+        processor = PopularDatasetsExplanation()
+        assert processor._default_value == "Browse popular datasets below and see what other citizens find interesting."
+
+    def test_form_name(self):
+        processor = PopularDatasetsExplanation()
+        assert processor.form_name == "popular-datasets-custom-explanation"
+
+    def test_title(self):
+        processor = PopularDatasetsExplanation()
+        assert processor.title == "Popular Datasets Section Explanation"
+
+    def test_parse_form_data_with_custom_value(self):
+        processor = PopularDatasetsExplanation()
+        form_data = {'popular-datasets-custom-explanation': 'Check out popular data'}
+        processor.parse_form_data(form_data)
+        assert processor.value == 'Check out popular data'
+
+
+class TestRecentDatasetsExplanation:
+    """Test RecentDatasetsExplanation processor"""
+
+    def test_default_value(self):
+        processor = RecentDatasetsExplanation()
+        assert processor._default_value == "Browse new or modified datasets below. Click to view details or explore content."
+
+    def test_form_name(self):
+        processor = RecentDatasetsExplanation()
+        assert processor.form_name == "recent-datasets-custom-explanation"
+
+    def test_title(self):
+        processor = RecentDatasetsExplanation()
+        assert processor.title == "Recent Datasets Section Explanation"
+
+    def test_parse_form_data_with_custom_value(self):
+        processor = RecentDatasetsExplanation()
+        form_data = {'recent-datasets-custom-explanation': 'See new datasets here'}
+        processor.parse_form_data(form_data)
+        assert processor.value == 'See new datasets here'
+
+
+class TestCustomNamingProcessor:
+    """Test CustomNamingProcessor with explanations"""
+
+    def test_processor_initialization(self):
+        processor = CustomNamingProcessor()
+        assert processor.groups is not None
+        assert processor.groups_explanation is not None
+        assert processor.showcases is not None
+        assert processor.showcases_explanation is not None
+        assert processor.popular_datasets is not None
+        assert processor.popular_datasets_explanation is not None
+        assert processor.recent_datasets is not None
+        assert processor.recent_datasets_explanation is not None
+
+    def test_naming_processors_tuple_includes_all_processors(self):
+        processor = CustomNamingProcessor()
+        assert len(processor.naming_processors) == 8
+        assert processor.groups in processor.naming_processors
+        assert processor.groups_explanation in processor.naming_processors
+        assert processor.showcases in processor.naming_processors
+        assert processor.showcases_explanation in processor.naming_processors
+        assert processor.popular_datasets in processor.naming_processors
+        assert processor.popular_datasets_explanation in processor.naming_processors
+        assert processor.recent_datasets in processor.naming_processors
+        assert processor.recent_datasets_explanation in processor.naming_processors
+
+    def test_get_custom_naming_with_all_fields(self):
+        processor = CustomNamingProcessor()
+        form_data = {
+            'groups-custom-name': 'Custom Groups',
+            'groups-custom-explanation': 'Custom groups explanation',
+            'showcases-custom-name': 'Custom Showcases',
+            'showcases-custom-explanation': 'Custom showcases explanation',
+            'popular-datasets-custom-name': 'Custom Popular',
+            'popular-datasets-custom-explanation': 'Custom popular explanation',
+            'recent-datasets-custom-name': 'Custom Recent',
+            'recent-datasets-custom-explanation': 'Custom recent explanation'
+        }
+        result = processor.get_custom_naming(form_data)
+
+        assert 'groups-custom-name' in result
+        assert result['groups-custom-name']['value'] == 'Custom Groups'
+        assert 'groups-custom-explanation' in result
+        assert result['groups-custom-explanation']['value'] == 'Custom groups explanation'
+
+        assert 'showcases-custom-name' in result
+        assert result['showcases-custom-name']['value'] == 'Custom Showcases'
+        assert 'showcases-custom-explanation' in result
+        assert result['showcases-custom-explanation']['value'] == 'Custom showcases explanation'
+
+        assert 'popular-datasets-custom-name' in result
+        assert result['popular-datasets-custom-name']['value'] == 'Custom Popular'
+        assert 'popular-datasets-custom-explanation' in result
+        assert result['popular-datasets-custom-explanation']['value'] == 'Custom popular explanation'
+
+        assert 'recent-datasets-custom-name' in result
+        assert result['recent-datasets-custom-name']['value'] == 'Custom Recent'
+        assert 'recent-datasets-custom-explanation' in result
+        assert result['recent-datasets-custom-explanation']['value'] == 'Custom recent explanation'
+
+    def test_get_custom_naming_with_defaults(self):
+        processor = CustomNamingProcessor()
+        form_data = {}
+        result = processor.get_custom_naming(form_data)
+
+        # Check that default values are used
+        assert result['groups-custom-explanation']['value'] == "As datasets are published, they are grouped into categories so you can learn about popular topics."
+        assert result['showcases-custom-explanation']['value'] == ""
+        assert result['popular-datasets-custom-explanation']['value'] == "Browse popular datasets below and see what other citizens find interesting."
+        assert result['recent-datasets-custom-explanation']['value'] == "Browse new or modified datasets below. Click to view details or explore content."
+
+    def test_get_custom_naming_with_mixed_values(self):
+        processor = CustomNamingProcessor()
+        form_data = {
+            'groups-custom-name': 'Custom Groups',
+            'groups-custom-explanation': '',  # Empty, should use default
+            'showcases-custom-name': '',
+            'showcases-custom-explanation': 'Custom showcases text',  # Custom value
+        }
+        result = processor.get_custom_naming(form_data)
+
+        assert result['groups-custom-name']['value'] == 'Custom Groups'
+        assert result['groups-custom-explanation']['value'] == "As datasets are published, they are grouped into categories so you can learn about popular topics."
+        assert result['showcases-custom-name']['value'] == 'Showcases'
+        assert result['showcases-custom-explanation']['value'] == 'Custom showcases text'


### PR DESCRIPTION
# Description
Allow system administrators to configure custom explanation text for each homepage section (groups, showcases, popular datasets and recent datasets) through the custom homepage admin form. This extends the existing custom naming functionality to include section descriptions.

- Adds support for custom explanation text on homepage sections
- Extends the custom homepage admin form with new explanation fields for groups, showcases, popular datasets, and recent datasets sections
- Includes test coverage for the new functionality