### PR TITLE
Accessibility fixes for keyboard navigation and screen readers

### DIFF
--- a/ckanext/opendata_theme/opengov_custom_theme/assets/css/keyboard-reorder.css
+++ b/ckanext/opendata_theme/opengov_custom_theme/assets/css/keyboard-reorder.css
@@ -1,0 +1,27 @@
+/* Visually hidden but accessible to screen readers.
+ * Bootstrap 3 ships .sr-only; duplicated here for resilience. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Highlight the item currently being keyboard-reordered. */
+.keyboard-reorder-active {
+  outline: 2px solid #005a9c;
+  outline-offset: -2px;
+  background-color: #e8f0fe;
+}
+
+/* Visible focus ring on list items while in reorder mode. */
+.reordering li:focus,
+.reordering .handle:focus {
+  outline: 2px solid #005a9c;
+  outline-offset: -2px;
+}

--- a/ckanext/opendata_theme/opengov_custom_theme/assets/js/keyboard-reorder.js
+++ b/ckanext/opendata_theme/opengov_custom_theme/assets/js/keyboard-reorder.js
@@ -1,0 +1,312 @@
+/* Keyboard-accessible reordering for resource and resource-view lists.
+ *
+ * Works alongside the existing jQuery UI Sortable modules (resource-reorder,
+ * resource-view-reorder).  Attach to the same container element via
+ * data-module="resource-reorder keyboard-reorder".
+ *
+ * Interaction model
+ * -----------------
+ * 1. The existing module adds the class .reordering when reorder mode is
+ *    enabled.  A MutationObserver detects this and sets up keyboard support.
+ * 2. With reorder mode active the user can Tab to a .handle element and press
+ *    Enter to begin keyboard reordering for that item.
+ * 3. Arrow Up / Arrow Down moves the item; Enter confirms; Escape cancels.
+ * 4. A visually-hidden aria-live region announces every state change.
+ */
+this.ckan.module('keyboard-reorder', function ($) {
+  return {
+    options: {},
+
+    /* ── state ────────────────────────────────────────────────── */
+    _isReorderMode: false,   // an item is actively being keyboard-moved
+    _activeItem: null,       // jQuery <li> currently being moved
+    _originalNextSibling: null, // DOM node that followed the item before move
+    _liveRegion: null,       // aria-live announcement element
+    _observer: null,         // MutationObserver for .reordering class
+    _reorderEnabled: false,  // tracks whether the container has .reordering
+
+    /* ── lifecycle ────────────────────────────────────────────── */
+
+    initialize: function () {
+      $.proxyAll(this, /_on/);
+
+      this._liveRegion = $(
+        '<div class="sr-only" aria-live="polite" aria-atomic="true"></div>'
+      ).appendTo(document.body);
+
+      this._instructionsId = 'keyboard-reorder-instructions-' + Date.now();
+      this._instructions = $(
+        '<div id="' + this._instructionsId + '" class="sr-only">' +
+        'Press Enter on a handle to start reordering. ' +
+        'Use Arrow Up and Arrow Down to move. ' +
+        'Press Enter to confirm or Escape to cancel.' +
+        '</div>'
+      ).appendTo(document.body);
+
+      this.el.attr('aria-describedby', this._instructionsId);
+
+      this._observer = new MutationObserver(this._onClassMutation);
+      this._observer.observe(this.el[0], {
+        attributes: true,
+        attributeFilter: ['class']
+      });
+
+      this.el.on('keydown.keyboardReorder', this._onKeydown);
+
+      // In case .reordering is already present when the module initialises
+      if (this.el.hasClass('reordering')) {
+        this._enableKeyboardReorder();
+      }
+    },
+
+    teardown: function () {
+      if (this._observer) {
+        this._observer.disconnect();
+      }
+      this._disableKeyboardReorder();
+      this.el.off('.keyboardReorder');
+      if (this._liveRegion) {
+        this._liveRegion.remove();
+      }
+      if (this._instructions) {
+        this._instructions.remove();
+      }
+    },
+
+    /* ── reorder-mode detection ───────────────────────────────── */
+
+    _onClassMutation: function () {
+      var hasClass = this.el.hasClass('reordering');
+      if (hasClass && !this._reorderEnabled) {
+        this._enableKeyboardReorder();
+      } else if (!hasClass && this._reorderEnabled) {
+        this._disableKeyboardReorder();
+      }
+    },
+
+    _enableKeyboardReorder: function () {
+      this._reorderEnabled = true;
+      var $items = this._getItems();
+
+      $items.attr('role', 'listitem');
+
+      // Disable links inside items so Tab stays on the handles
+      $items.find('a').not('.handle').attr('tabindex', '-1');
+
+      // Label each handle with the item's visible name so screen readers
+      // announce something meaningful instead of an empty link.
+      var $handles = $items.find('.handle');
+      $handles.each(function () {
+        var $handle = $(this);
+        var $item = $handle.closest('li');
+        var name = $item.find('.heading').text().trim() ||
+                   $item.find('a').first().text().trim() ||
+                   'item';
+        $handle.attr({
+          'aria-label': 'Reorder ' + name,
+          'role': 'button'
+        });
+      });
+
+      // Roving tabindex on handles: first handle is tabbable, rest are not
+      $handles.attr('tabindex', '-1');
+      $handles.first().attr('tabindex', '0');
+    },
+
+    _disableKeyboardReorder: function () {
+      if (this._isReorderMode) {
+        this._cancelReorder();
+      }
+      this._reorderEnabled = false;
+
+      var $items = this._getItems();
+      $items.removeAttr('role');
+      $items.find('a').not('.handle').removeAttr('tabindex');
+      $items.find('.handle').removeAttr('tabindex').removeAttr('aria-label').removeAttr('role');
+      $items.removeClass('keyboard-reorder-active');
+    },
+
+    /* ── keyboard handling ────────────────────────────────────── */
+
+    _onKeydown: function (e) {
+      if (!this._reorderEnabled) {
+        return;
+      }
+
+      var key = e.key;
+
+      // Enter on a .handle starts reorder mode for that item
+      if (
+        key === 'Enter' &&
+        !this._isReorderMode &&
+        $(e.target).hasClass('handle')
+      ) {
+        e.preventDefault();
+        this._startReorder($(e.target).closest('li'));
+        return;
+      }
+
+      if (!this._isReorderMode) {
+        // When not in reorder mode, support roving tabindex navigation
+        if (key === 'ArrowUp' || key === 'ArrowDown') {
+          var $focused = $(e.target).closest('li');
+          if ($focused.length && this.el.has($focused).length) {
+            e.preventDefault();
+            this._rovingMove($focused, key === 'ArrowUp' ? -1 : 1);
+          }
+        }
+        return;
+      }
+
+      // While in reorder mode, key events apply to the active item
+      switch (key) {
+        case 'ArrowUp':
+          e.preventDefault();
+          this._moveItem(-1);
+          break;
+        case 'ArrowDown':
+          e.preventDefault();
+          this._moveItem(1);
+          break;
+        case 'Enter':
+          e.preventDefault();
+          this._confirmReorder();
+          break;
+        case 'Escape':
+          e.preventDefault();
+          this._cancelReorder();
+          break;
+      }
+    },
+
+    /* ── roving tabindex (when reorder mode is NOT active) ───── */
+
+    _rovingMove: function ($currentItem, direction) {
+      var $items = this._getItems();
+      var idx = $items.index($currentItem);
+      var newIdx = idx + direction;
+
+      if (newIdx < 0 || newIdx >= $items.length) {
+        return;
+      }
+
+      // Move roving tabindex across all handles
+      var $allHandles = $items.find('.handle');
+      $allHandles.attr('tabindex', '-1');
+
+      var $nextHandle = $items.eq(newIdx).find('.handle');
+      if ($nextHandle.length) {
+        $nextHandle.attr('tabindex', '0').focus();
+      }
+    },
+
+    /* ── keyboard reorder operations ──────────────────────────── */
+
+    _startReorder: function ($item) {
+      this._isReorderMode = true;
+      this._activeItem = $item;
+
+      // Remember the next sibling so we can restore on cancel
+      this._originalNextSibling = $item[0].nextElementSibling;
+
+      $item.addClass('keyboard-reorder-active');
+
+      this._announce(
+        'Reordering started. Use arrow keys to move. ' +
+        'Press Escape to cancel, Enter to save.'
+      );
+    },
+
+    _moveItem: function (direction) {
+      var $item = this._activeItem;
+      var $items = this._getItems();
+      var currentIndex = $items.index($item);
+      var targetIndex = currentIndex + direction;
+
+      if (targetIndex < 0 || targetIndex >= $items.length) {
+        return;
+      }
+
+      var $target = $items.eq(targetIndex);
+
+      if (direction < 0) {
+        $item.insertBefore($target);
+      } else {
+        $item.insertAfter($target);
+      }
+
+      // Update roving tabindex and keep focus on the moved item's handle
+      var $allHandles = this._getItems().find('.handle');
+      $allHandles.attr('tabindex', '-1');
+      var $handle = $item.find('.handle');
+      $handle.attr('tabindex', '0').focus();
+
+      var updatedItems = this._getItems();
+      var newPosition = updatedItems.index($item) + 1;
+
+      this._announce(
+        'Moved to position ' + newPosition + ' of ' + updatedItems.length
+      );
+    },
+
+    _confirmReorder: function () {
+      var $item = this._activeItem;
+
+      this._isReorderMode = false;
+      this._activeItem = null;
+      this._originalNextSibling = null;
+
+      if ($item) {
+        $item.removeClass('keyboard-reorder-active');
+        $item.find('.handle').focus();
+      }
+
+      this._announce('Order saved');
+    },
+
+    _cancelReorder: function () {
+      var $item = this._activeItem;
+
+      this._isReorderMode = false;
+      this._activeItem = null;
+
+      if ($item) {
+        $item.removeClass('keyboard-reorder-active');
+
+        // Restore original position
+        if (this._originalNextSibling) {
+          $item.insertBefore(this._originalNextSibling);
+        } else {
+          // Was the last item — append to end
+          this.el.append($item);
+        }
+
+        // Update roving tabindex and return focus to the handle
+        var $allHandles = this._getItems().find('.handle');
+        $allHandles.attr('tabindex', '-1');
+        $item.find('.handle').attr('tabindex', '0').focus();
+      }
+
+      this._originalNextSibling = null;
+      this._announce('Reordering cancelled');
+    },
+
+    /* ── helpers ───────────────────────────────────────────────── */
+
+    _getItems: function () {
+      return this.el.children('li');
+    },
+
+    /**
+     * Update the aria-live region. Uses a clear-then-set pattern so that
+     * repeated identical messages are still announced.
+     */
+    _announce: function (message) {
+      var region = this._liveRegion;
+      region.text('');
+      setTimeout(function () {
+        region.text(message);
+      }, 50);
+    }
+  };
+});

--- a/ckanext/opendata_theme/opengov_custom_theme/assets/js/theme.js
+++ b/ckanext/opendata_theme/opengov_custom_theme/assets/js/theme.js
@@ -252,7 +252,39 @@ function setupCkanFileUploadKeyboard() {
   });
 }
 
+/**
+ * Server-rendered validation errors (.error-explanation summary, .error-block per-field)
+ * are static HTML present on page load. Mark them with role="alert" so assistive tech
+ * conveys error semantics, and move focus to the summary so VoiceOver reads it instead
+ * of auto-reading from the top of the page.
+ */
+function setupFormErrorA11y() {
+  var $summary = $('.error-explanation');
+  var $fieldErrors = $('.error-block');
+
+  if (!$summary.length && !$fieldErrors.length) {
+    return;
+  }
+
+  $summary.each(function () {
+    this.setAttribute('role', 'alert');
+  });
+
+  $fieldErrors.each(function () {
+    this.setAttribute('role', 'alert');
+  });
+
+  if ($summary.length) {
+    var first = $summary[0];
+    if (!first.hasAttribute('tabindex')) {
+      first.setAttribute('tabindex', '-1');
+    }
+    first.focus();
+  }
+}
+
 $(document).ready(function () {
+  setupFormErrorA11y();
   setupResourceViewFilterValueSelect2A11y();
   setupResourceViewFiltersSelect2DropdownSearchA11y();
   setupResourceViewFiltersEnterKey();

--- a/ckanext/opendata_theme/opengov_custom_theme/assets/js/theme.js
+++ b/ckanext/opendata_theme/opengov_custom_theme/assets/js/theme.js
@@ -153,6 +153,86 @@ function setupResourceViewFiltersSelect2DropdownSearchA11y() {
   });
 }
 
+/**
+ * Dataset create/edit form: Select2 3.x on License and Organization replaces the
+ * native <select> with custom DOM whose focusser has aria-labelledby pointing at
+ * the selected value, not the field label.  Resolve the <label for> text and apply
+ * it as aria-label on each Select2 focusser.
+ *
+ * CKAN modules initialise asynchronously (after an AJAX locale fetch), so the
+ * Select2 containers may not exist during document.ready or window.load.  A
+ * MutationObserver on each field's parent detects late container insertion.
+ */
+function setupDatasetFormFieldA11y() {
+  var select2Ids = ['field-license', 'field-organizations'];
+
+  function fixSelect2Field(id) {
+    var $sel = $('#' + id);
+    if (!$sel.length) {
+      return false;
+    }
+    var $container = $sel.prev('.select2-container');
+    if (!$container.length) {
+      return false;
+    }
+    var $label = $('label[for="' + id + '"]');
+    if (!$label.length || !$.trim($label.text())) {
+      return true;
+    }
+    if (!$label.attr('id')) {
+      $label.attr('id', 'label-' + id);
+    }
+    var $focusser = $container.find('input.select2-focusser');
+    if ($focusser.length) {
+      var chosenId = $focusser.attr('aria-labelledby') || '';
+      $focusser.attr('aria-labelledby', $label.attr('id') + (chosenId ? ' ' + chosenId : ''));
+    }
+    stripEmptySelect2OffscreenLabels($container);
+    return true;
+  }
+
+  $.each(select2Ids, function (_i, id) {
+    if (fixSelect2Field(id)) {
+      return;
+    }
+    var el = document.getElementById(id);
+    if (!el || !el.parentNode) {
+      return;
+    }
+    var mo = new MutationObserver(function () {
+      if (fixSelect2Field(id)) {
+        mo.disconnect();
+      }
+    });
+    mo.observe(el.parentNode, { childList: true });
+  });
+}
+
+/**
+ * When the Select2 dropdown opens for License or Organization on the dataset form,
+ * copy the field label onto the search input so VoiceOver announces it.
+ */
+function setupDatasetFormSelect2DropdownSearchA11y() {
+  $(document).on('select2-open', '#field-license, #field-organizations', function () {
+    var $orig = $(this);
+    var id = $orig.attr('id');
+    var $label = $('label[for="' + id + '"]');
+    var labelText = $label.length ? $.trim($label.text()) : '';
+    if (!labelText) {
+      return;
+    }
+    window.requestAnimationFrame(function () {
+      window.requestAnimationFrame(function () {
+        var $drop = $('.select2-drop-active');
+        if (!$drop.length) {
+          $drop = $('#select2-drop');
+        }
+        $drop.find('.select2-input').attr('aria-label', labelText);
+      });
+    });
+  });
+}
+
 function isEnterOrSpaceKey(e) {
   var key = e.key || '';
   var code = e.which || e.keyCode;
@@ -289,6 +369,8 @@ $(document).ready(function () {
   setupResourceViewFiltersSelect2DropdownSearchA11y();
   setupResourceViewFiltersEnterKey();
   setupCkanFileUploadKeyboard();
+  setupDatasetFormFieldA11y();
+  setupDatasetFormSelect2DropdownSearchA11y();
 });
 
 // Close popover on pressing Escape key

--- a/ckanext/opendata_theme/opengov_custom_theme/assets/webassets.yml
+++ b/ckanext/opendata_theme/opengov_custom_theme/assets/webassets.yml
@@ -1,3 +1,8 @@
+theme-css:
+  output: opengov_custom_theme/%(version)s_theme.css
+  contents:
+    - css/keyboard-reorder.css
+
 theme-js:
   filters: rjsmin
   output: opengov_custom_theme/%(version)s_theme.js
@@ -6,3 +11,4 @@ theme-js:
       - base/main
   contents:
     - js/theme.js
+    - js/keyboard-reorder.js

--- a/ckanext/opendata_theme/opengov_custom_theme/templates/package/resources.html
+++ b/ckanext/opendata_theme/opengov_custom_theme/templates/package/resources.html
@@ -1,0 +1,17 @@
+{% ckan_extends %}
+
+{% block primary_content_inner %}
+  {% if pkg.resources %}
+    <ul class="resource-list" role="list" aria-roledescription="sortable list"
+      {% if has_reorder %} data-module="resource-reorder keyboard-reorder" data-module-id="{{ pkg.id }}"{% endif %}>
+      {% set can_edit = h.check_access('package_update', {'id':pkg.id }) %}
+      {% for resource in pkg.resources %}
+        {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=resource, url_is_edit=true, can_edit=can_edit, is_activity_archive=False %}
+      {% endfor %}
+    </ul>
+  {% else %}
+    {% trans url=h.url_for(pkg.type ~ '_resource.new', id=pkg.name) %}
+      <p class="empty">This dataset has no data, <a href="{{ url }}">why not add some?</a></p>
+    {% endtrans %}
+  {% endif %}
+{% endblock %}

--- a/ckanext/opendata_theme/opengov_custom_theme/templates/package/snippets/resource_views_list.html
+++ b/ckanext/opendata_theme/opengov_custom_theme/templates/package/snippets/resource_views_list.html
@@ -1,0 +1,29 @@
+{% set views_created = views or resource_preview %}
+{% if views_created %}
+  {% if is_edit %}
+  <ul class="nav {{ extra_class }}" data-module="resource-view-reorder keyboard-reorder" data-module-id="{{ views[0].resource_id }}" role="list" aria-roledescription="sortable list">
+  {% else %}
+  <ul class="nav {{ extra_class }}" {{ extra_attributes }}>
+  {% endif %}
+    {% if resource_preview %}
+      <li{% if not view_id %} class="active"{% endif %}>
+        <a href="{{ h.url_for(pkg.type ~ '_resource.read', id=pkg.name, resource_id=resource.id) }}" >
+          <i class="fa icon fa-eye-open"></i>
+          {{ _("Resource Preview") }}
+        </a>
+      </li>
+  {% endif %}
+
+  {% set current_filters = request.args.get('filters') %}
+  {% for view in views %}
+  	{% set is_selected = true if view_id == view.id else false %}
+    {% snippet "package/snippets/resource_views_list_item.html",
+       view=view,
+       pkg=pkg,
+       is_edit=is_edit,
+       is_selected=is_selected,
+       current_filters=current_filters
+    %}
+  {% endfor %}
+</ul>
+{% endif %}

--- a/ckanext/opendata_theme/opengov_custom_theme/templates/page.html
+++ b/ckanext/opendata_theme/opengov_custom_theme/templates/page.html
@@ -6,6 +6,7 @@
 
 {% block styles %}
   {{ super() }}
+  {% asset 'opengov_custom_theme/theme-css' %}
   {% asset 'opengov_custom_theme/theme-js' %}
 {% endblock %}
 


### PR DESCRIPTION
# Description

- Add keyboard-based reordering for resources and resource views (drag-and-drop alternative using arrow keys)
- Ensure screen readers announce validation error messages immediately by marking them with role="alert" and shifting focus to the error summary
- Fix VoiceOver not reading form labels for the License and Organization Select2 dropdowns on the dataset create/edit form by correcting aria-labelledby to reference both the field label and the selected value