### PR TITLE
chore: remove contact link from Boston's custom header

### DIFF
--- a/ckanext/opendata_theme/extended_themes/bostonma/templates/page.html
+++ b/ckanext/opendata_theme/extended_themes/bostonma/templates/page.html
@@ -95,9 +95,6 @@
       <li class="menu__item is-leaf leaf secondary-menu-item">
         <a href="{{ h.url_for('about') }}" class="menu__link">{{ _('About') }}</a>
       </li>
-      <li class="menu__item is-leaf leaf secondary-menu-item">
-        <a href="{{ h.url_for('contact_form') }}" class="menu__link">{{ _('Contact') }}</a>
-      </li>
     </ul>
   </div>
 </nav>


### PR DESCRIPTION
# Description
Remove the contact link from Boston's custom header