### PR TITLE
feat: update file name of data dictionary download

### DIFF
--- a/ckanext/opendata_theme/opengov_custom_theme/utils.py
+++ b/ckanext/opendata_theme/opengov_custom_theme/utils.py
@@ -1,4 +1,5 @@
 import unicodecsv as csv
+from ckanapi.datapackage import _convert_to_datapackage_resource
 from ckan.plugins.toolkit import (
     ObjectNotFound,
     NotAuthorized,
@@ -7,6 +8,19 @@ from ckan.plugins.toolkit import (
     get_action,
     _
 )
+
+
+def dictionary_filename(resource_id):
+    # Build the base name the same way ckanext-downloadall names saved resource
+    # files: ckanapi's _convert_to_datapackage_resource slugifies and lowercases
+    # the resource name (falling back to the resource id when unnamed).
+    try:
+        resource = get_action('resource_show')(None, {'id': resource_id})
+    except (ObjectNotFound, NotAuthorized):
+        resource = {'id': resource_id}
+
+    base = _convert_to_datapackage_resource(resource).get('name', resource_id)
+    return '{base}-data-dictionary.csv'.format(base=base)
 
 
 def dictionary_download(resource_id, response):
@@ -24,7 +38,8 @@ def dictionary_download(resource_id, response):
     if hasattr(response, u'headers'):
         response.headers['Content-Type'] = 'text/csv; charset=utf-8'
         response.headers['Content-disposition'] = (
-            'attachment; filename="{name}-data-dictionary.csv"'.format(name=resource_id))
+            'attachment; filename="{filename}"'.format(
+                filename=dictionary_filename(resource_id)))
 
     if check_ckan_version(min_version='2.9.0'):
         wr = csv.writer(response.stream, encoding='utf-8')

--- a/ckanext/opendata_theme/opengov_custom_theme/utils.py
+++ b/ckanext/opendata_theme/opengov_custom_theme/utils.py
@@ -11,15 +11,15 @@ from ckan.plugins.toolkit import (
 
 
 def dictionary_filename(resource_id):
-    # Build the base name the same way ckanext-downloadall names saved resource
-    # files: ckanapi's _convert_to_datapackage_resource slugifies and lowercases
-    # the resource name (falling back to the resource id when unnamed).
+    # Reuse ckanext-downloadall's naming so the data dictionary matches its
+    # saved resource files. _convert_to_datapackage_resource is a private
+    # ckanapi symbol, so guard against it (or resource_show) raising and fall
+    # back to the resource id.
     try:
         resource = get_action('resource_show')(None, {'id': resource_id})
-    except (ObjectNotFound, NotAuthorized):
-        resource = {'id': resource_id}
-
-    base = _convert_to_datapackage_resource(resource).get('name', resource_id)
+        base = _convert_to_datapackage_resource(resource).get('name', resource_id)
+    except Exception:
+        base = resource_id
     return '{base}-data-dictionary.csv'.format(base=base)
 
 

--- a/ckanext/opendata_theme/tests/opengov_custom_theme/test_custom_theme.py
+++ b/ckanext/opendata_theme/tests/opengov_custom_theme/test_custom_theme.py
@@ -21,3 +21,18 @@ class TestDataDictionaryDownload(object):
             "column,type,label,description\r\n"
             "book,text,,\r\n" == response.get_data(as_text=True)
         )
+
+    def test_data_dictionary_download_filename_uses_slugified_name(self, app):
+        resource = factories.Resource(name="My Great Data!")
+        data = {
+            "resource_id": resource["id"],
+            "force": True,
+            "records": [{u"book": "annakarenina"}],
+        }
+        helpers.call_action("datastore_create", **data)
+
+        response = app.get(f'/datastore/dictionary_download/{resource["id"]}')
+        assert (
+            'filename="my-great-data-data-dictionary.csv"'
+            in response.headers["Content-disposition"]
+        )

--- a/ckanext/opendata_theme/tests/opengov_custom_theme/test_custom_theme.py
+++ b/ckanext/opendata_theme/tests/opengov_custom_theme/test_custom_theme.py
@@ -2,6 +2,8 @@ import pytest
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
 
+from ckanext.opendata_theme.opengov_custom_theme.utils import dictionary_filename
+
 
 @pytest.mark.usefixtures('with_plugins', 'clean_db')
 @pytest.mark.ckan_config("ckan.plugins", "datastore opengov_custom_theme")
@@ -35,4 +37,12 @@ class TestDataDictionaryDownload(object):
         assert (
             'filename="my-great-data-data-dictionary.csv"'
             in response.headers["Content-disposition"]
+        )
+
+    def test_dictionary_filename_falls_back_to_resource_id(self):
+        # An unknown resource id makes resource_show raise; the filename should
+        # fall back to the raw resource id rather than error out.
+        assert (
+            dictionary_filename("does-not-exist")
+            == "does-not-exist-data-dictionary.csv"
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bleach>=3.1.4
-ckanapi>=4.1
+ckanapi>=4.1,<5
 six>=1.12.0
 tinycss2>=1.1.1
 wcag_contrast_ratio>=0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 bleach>=3.1.4
+ckanapi>=4.1
 six>=1.12.0
 tinycss2>=1.1.1
 wcag_contrast_ratio>=0.9


### PR DESCRIPTION
## Summary

Updates `dictionary_download` so the generated CSV filename matches how [ckanext-downloadall](https://github.com/OpenGov-OpenData/ckanext-downloadall/blob/master/ckanext/downloadall/tasks.py) names saved resource files.

Previously the download used the raw `resource_id` (`{uuid}-data-dictionary.csv`). downloadall names resource files via `ckanapi.datapackage`, which slugifies and lowercases the resource name. We now reuse the same `ckanapi` helper (`_convert_to_datapackage_resource`) to derive the base name, falling back to the `resource_id` when the resource is unnamed or unreadable.

Examples:
- `"My Great Data!"` → `my-great-data-data-dictionary.csv`
- no name → `{resource_id}-data-dictionary.csv`
- `"Budget 2024"` → `budget-2024-data-dictionary.csv`

## Changes
- `utils.py`: add `dictionary_filename()` helper; `dictionary_download` sets `Content-disposition` from it.
- `requirements.txt`: add `ckanapi>=4.1`.
- Test: assert a resource named `"My Great Data!"` yields `my-great-data-data-dictionary.csv`.

## Notes
- `_convert_to_datapackage_resource` is an underscore-prefixed (private) `ckanapi` function; downloadall relies on the same module internals, so we stay consistent with it, but it's an upstream API that could change.

## Test plan
- [ ] `pytest ckanext/opendata_theme/tests/opengov_custom_theme/test_custom_theme.py` in a CKAN environment (CKAN isn't installed locally). Naming logic verified directly against `ckanapi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)