### PR TITLE
feat: show data dictionary save success client-side

### DIFF
--- a/ckanext/opendata_theme/opengov_custom_theme/assets/js/data-dict-flash.js
+++ b/ckanext/opendata_theme/opengov_custom_theme/assets/js/data-dict-flash.js
@@ -90,19 +90,7 @@ this.ckan.module('data-dict-flash', function ($) {
 
       // 3. Server-flash dedupe: if the server already rendered a success flash
       //    (i.e. the shared-session fix has landed), do nothing.
-      var $existingSuccess = $('.flash-messages .alert-success');
-      if ($existingSuccess.length) {
-        return false;
-      }
-      // Also skip if an alert already carries the same message text.
-      var message = this.options.message;
-      var duplicate = false;
-      $existingSuccess.each(function () {
-        if ($(this).text().indexOf(message) !== -1) {
-          duplicate = true;
-        }
-      });
-      if (duplicate) {
+      if ($('.flash-messages .alert-success').length) {
         return false;
       }
 

--- a/ckanext/opendata_theme/opengov_custom_theme/assets/js/data-dict-flash.js
+++ b/ckanext/opendata_theme/opengov_custom_theme/assets/js/data-dict-flash.js
@@ -1,0 +1,164 @@
+/* Client-side success flash for the data dictionary edit form.
+ *
+ * Why this exists
+ * ---------------
+ * Saving the data dictionary does a POST -> h.flash_success() -> 302 redirect
+ * back to the same URL (Post/Redirect/Get).  When CKAN runs across multiple
+ * Kubernetes pods with non-shared sessions, the flash cookie set by the pod
+ * that handled the POST is often not read by the pod that serves the redirect
+ * GET, so the success message is lost until a later navigation.
+ *
+ * This module is a pod-routing-agnostic STOPGAP: on submit it records a flag in
+ * sessionStorage, and on the next page load it renders the success alert itself
+ * -- but only if the server-side flash isn't already present.  Once the real
+ * shared-session fix lands, the server flash shows up, guard #3 suppresses this
+ * one, and the module can be removed cleanly.
+ *
+ * Attach via a marker element inside the dictionary <form>:
+ *   <span data-module="data-dict-flash" data-module-message="..."></span>
+ */
+this.ckan.module('data-dict-flash', function ($) {
+  return {
+    options: {
+      message: ''
+    },
+
+    /* ── state ────────────────────────────────────────────────── */
+    _key: null,      // sessionStorage key, scoped to this dictionary URL
+    _$form: null,    // the enclosing dictionary <form>
+
+    /* Time within which a stored flag is trusted as "just submitted".
+     * A PRG redirect completes in ~1-2s; 10s leaves headroom while bounding
+     * the residual false-positive (POST fails, user manually navigates back
+     * to the GET URL while the flag is still live).  This cannot be fully
+     * eliminated client-side without server cooperation -- accepted trade-off
+     * for a temporary stopgap. */
+    FRESHNESS_MS: 10000,
+
+    /* ── lifecycle ────────────────────────────────────────────── */
+
+    initialize: function () {
+      $.proxyAll(this, /_on/);
+
+      this._key = 'ckanext-opendata:data-dict-flash:' + window.location.pathname;
+
+      // Read-then-clear: pull the stored value, then remove it immediately so a
+      // flag never survives into an unrelated later reload, regardless of
+      // whether we decide to render below.
+      var raw = this._read();
+      this._clear();
+
+      this._$form = this.el.closest('form');
+      if (this._$form.length) {
+        this._$form.on('submit.dataDictFlash', this._onSubmit);
+      }
+
+      if (this._shouldRender(raw)) {
+        this._renderSuccess();
+      }
+    },
+
+    teardown: function () {
+      if (this._$form && this._$form.length) {
+        this._$form.off('.dataDictFlash');
+      }
+      this._$form = null;
+      // Intentionally leave any rendered alert in place.
+    },
+
+    /* ── submit handling ──────────────────────────────────────── */
+
+    _onSubmit: function () {
+      // There is a single `save` button; binding at form level also covers
+      // Enter-to-submit.
+      this._write({ t: Date.now() });
+    },
+
+    /* ── render decision ──────────────────────────────────────── */
+
+    /* Render the synthetic success alert only if ALL guards hold. */
+    _shouldRender: function (payload) {
+      // 1. Flag present and parseable.
+      if (!payload || typeof payload.t !== 'number') {
+        return false;
+      }
+
+      // 2. Freshness window.
+      if (Date.now() - payload.t > this.FRESHNESS_MS) {
+        return false;
+      }
+
+      // 3. Server-flash dedupe: if the server already rendered a success flash
+      //    (i.e. the shared-session fix has landed), do nothing.
+      var $existingSuccess = $('.flash-messages .alert-success');
+      if ($existingSuccess.length) {
+        return false;
+      }
+      // Also skip if an alert already carries the same message text.
+      var message = this.options.message;
+      var duplicate = false;
+      $existingSuccess.each(function () {
+        if ($(this).text().indexOf(message) !== -1) {
+          duplicate = true;
+        }
+      });
+      if (duplicate) {
+        return false;
+      }
+
+      // 4. Error-markup guard: never claim success when the page shows errors.
+      if ($('.error-explanation, .alert-danger, .alert-error, .control-group.error').length) {
+        return false;
+      }
+
+      return true;
+    },
+
+    _renderSuccess: function () {
+      var $container = $('.flash-messages');
+      // Core always renders this container; treat absence as purely defensive.
+      if (!$container.length) {
+        return;
+      }
+
+      var $alert = $('<div class="alert fade in alert-success" role="alert"></div>')
+        .text(this.options.message);
+
+      $container.append($alert);
+
+      // Pass through core's notify helper so the alert gets the same dismiss
+      // button and Bootstrap wiring as server-rendered flashes. It lives on the
+      // module sandbox (notify.js does ckan.sandbox.extend({notify: notify})).
+      if (this.sandbox.notify && this.sandbox.notify.initialize) {
+        this.sandbox.notify.initialize($alert);
+      }
+    },
+
+    /* ── sessionStorage helpers (defensive against disabled storage) ─ */
+
+    _read: function () {
+      try {
+        var raw = window.sessionStorage.getItem(this._key);
+        return raw ? JSON.parse(raw) : null;
+      } catch (e) {
+        return null;
+      }
+    },
+
+    _write: function (payload) {
+      try {
+        window.sessionStorage.setItem(this._key, JSON.stringify(payload));
+      } catch (e) {
+        // Storage unavailable/full: nothing to do -- stopgap simply no-ops.
+      }
+    },
+
+    _clear: function () {
+      try {
+        window.sessionStorage.removeItem(this._key);
+      } catch (e) {
+        // ignore
+      }
+    }
+  };
+});

--- a/ckanext/opendata_theme/opengov_custom_theme/assets/webassets.yml
+++ b/ckanext/opendata_theme/opengov_custom_theme/assets/webassets.yml
@@ -12,3 +12,4 @@ theme-js:
   contents:
     - js/theme.js
     - js/keyboard-reorder.js
+    - js/data-dict-flash.js

--- a/ckanext/opendata_theme/opengov_custom_theme/templates/datastore/dictionary.html
+++ b/ckanext/opendata_theme/opengov_custom_theme/templates/datastore/dictionary.html
@@ -3,4 +3,10 @@
 {% block dictionary_form %}
     <h2>Edit Data Dictionary</h2>
     {{ super() }}
+    {# Stopgap: show the save success message client-side, since the server-side
+       session flash is unreliable across non-shared-session Kubernetes pods.
+       Remove once the shared-session fix lands. The msgid must stay byte-identical
+       to ckanext/datastore/blueprint.py so existing translations resolve. #}
+    <span data-module="data-dict-flash"
+          data-module-message="{{ _('Data Dictionary saved. Any type overrides will take effect when the resource is next uploaded to DataStore') }}"></span>
 {% endblock %}


### PR DESCRIPTION
## Problem

On the data dictionary edit page, clicking **Save** does a normal `POST` → `h.flash_success(...)` → **302 redirect** back to the same URL (Post/Redirect/Get). The success message renders on the reloaded page.

Because CKAN runs across multiple Kubernetes pods **without shared sessions**, the flash cookie set by the pod that handled the `POST` is frequently not read by the pod that serves the redirect `GET`, so the success message is lost and only appears after some later navigation. Users report the message doesn't show until they navigate away.

## Change

A **client-side, pod-routing-agnostic stopgap** until the shared-session fix lands:

- New `data-dict-flash` CKAN module (`assets/js/data-dict-flash.js`): on submit it records a timestamped flag in `sessionStorage` keyed to the dictionary URL; on the next page load it renders the success alert into `.flash-messages` itself.
- Attached via an inert `<span data-module="data-dict-flash" data-module-message="...">` marker in the overridden `dictionary_form` block. The message is sourced from Jinja `_()` using the **byte-identical msgid** to core, so existing translations resolve — no hardcoded English in JS.
- The injected alert is passed through `ckan.sandbox.notify.initialize()` so it gets the same **`×` dismiss button** and Bootstrap wiring as server-rendered flashes.
- Added to the `theme-js` bundle in `webassets.yml`.

### Auto-suppression

The alert renders **only** when all guards hold: the flag is fresh (≤10s), **no server `alert-success` is already present**, and no error markup is shown. So once the real shared-session fix lands and the server flash reappears, this stopgap suppresses itself and can be removed cleanly.

## Testing

Verified locally (single instance, no k8s) by planting the flag via the console and reloading:

```js
sessionStorage.setItem(
  'ckanext-opendata:data-dict-flash:' + location.pathname,
  JSON.stringify({ t: Date.now() })
);
location.reload();
```

- ✅ Green success alert renders with a working `×` dismiss button.
- ✅ Flag is cleared on load (read-then-clear); no stale alert on later reloads.
- ✅ Stale flag (>10s) and no-flag cases render nothing.
- ✅ With the server flash present (normal single-instance save), only one alert shows — the stopgap suppresses itself (no duplicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)